### PR TITLE
Change tuple format as flow-sequence

### DIFF
--- a/VYaml.Core/Serialization/Formatters/TupleFormatter.cs
+++ b/VYaml.Core/Serialization/Formatters/TupleFormatter.cs
@@ -14,7 +14,7 @@ namespace VYaml.Serialization
                 return;
             }
 
-            emitter.BeginSequence();
+            emitter.BeginSequence(SequenceStyle.Flow);
             context.Serialize(ref emitter, value.Item1);
             emitter.EndSequence();
         }
@@ -43,7 +43,7 @@ namespace VYaml.Serialization
                 return;
             }
 
-            emitter.BeginSequence();
+            emitter.BeginSequence(SequenceStyle.Flow);
             context.Serialize(ref emitter, value.Item1);
             context.Serialize(ref emitter, value.Item2);
             emitter.EndSequence();
@@ -74,7 +74,7 @@ namespace VYaml.Serialization
                 return;
             }
 
-            emitter.BeginSequence();
+            emitter.BeginSequence(SequenceStyle.Flow);
             context.Serialize(ref emitter, value.Item1);
             context.Serialize(ref emitter, value.Item2);
             context.Serialize(ref emitter, value.Item3);
@@ -107,7 +107,7 @@ namespace VYaml.Serialization
                 return;
             }
 
-            emitter.BeginSequence();
+            emitter.BeginSequence(SequenceStyle.Flow);
             context.Serialize(ref emitter, value.Item1);
             context.Serialize(ref emitter, value.Item2);
             context.Serialize(ref emitter, value.Item3);
@@ -143,7 +143,7 @@ namespace VYaml.Serialization
                 return;
             }
 
-            emitter.BeginSequence();
+            emitter.BeginSequence(SequenceStyle.Flow);
             context.Serialize(ref emitter, value.Item1);
             context.Serialize(ref emitter, value.Item2);
             context.Serialize(ref emitter, value.Item3);
@@ -181,7 +181,7 @@ namespace VYaml.Serialization
                 return;
             }
 
-            emitter.BeginSequence();
+            emitter.BeginSequence(SequenceStyle.Flow);
             context.Serialize(ref emitter, value.Item1);
             context.Serialize(ref emitter, value.Item2);
             context.Serialize(ref emitter, value.Item3);
@@ -220,7 +220,7 @@ namespace VYaml.Serialization
                 return;
             }
 
-            emitter.BeginSequence();
+            emitter.BeginSequence(SequenceStyle.Flow);
             context.Serialize(ref emitter, value.Item1);
             context.Serialize(ref emitter, value.Item2);
             context.Serialize(ref emitter, value.Item3);
@@ -262,7 +262,7 @@ namespace VYaml.Serialization
                 return;
             }
 
-            emitter.BeginSequence();
+            emitter.BeginSequence(SequenceStyle.Flow);
             context.Serialize(ref emitter, value.Item1);
             context.Serialize(ref emitter, value.Item2);
             context.Serialize(ref emitter, value.Item3);

--- a/VYaml.Core/Serialization/Formatters/ValueTupleFormatter.cs
+++ b/VYaml.Core/Serialization/Formatters/ValueTupleFormatter.cs
@@ -8,7 +8,7 @@ namespace VYaml.Serialization
     {
         public void Serialize(ref Utf8YamlEmitter emitter, ValueTuple<T1> value, YamlSerializationContext context)
         {
-            emitter.BeginSequence();
+            emitter.BeginSequence(SequenceStyle.Flow);
             context.Serialize(ref emitter, value.Item1);
             emitter.EndSequence();
         }
@@ -31,7 +31,7 @@ namespace VYaml.Serialization
     {
         public void Serialize(ref Utf8YamlEmitter emitter, (T1, T2) value, YamlSerializationContext context)
         {
-            emitter.BeginSequence();
+            emitter.BeginSequence(SequenceStyle.Flow);
             context.Serialize(ref emitter, value.Item1);
             context.Serialize(ref emitter, value.Item2);
             emitter.EndSequence();
@@ -56,7 +56,7 @@ namespace VYaml.Serialization
     {
         public void Serialize(ref Utf8YamlEmitter emitter, (T1, T2, T3) value, YamlSerializationContext context)
         {
-            emitter.BeginSequence();
+            emitter.BeginSequence(SequenceStyle.Flow);
             context.Serialize(ref emitter, value.Item1);
             context.Serialize(ref emitter, value.Item2);
             context.Serialize(ref emitter, value.Item3);
@@ -83,7 +83,7 @@ namespace VYaml.Serialization
     {
         public void Serialize(ref Utf8YamlEmitter emitter, (T1, T2, T3, T4) value, YamlSerializationContext context)
         {
-            emitter.BeginSequence();
+            emitter.BeginSequence(SequenceStyle.Flow);
             context.Serialize(ref emitter, value.Item1);
             context.Serialize(ref emitter, value.Item2);
             context.Serialize(ref emitter, value.Item3);
@@ -112,7 +112,7 @@ namespace VYaml.Serialization
     {
         public void Serialize(ref Utf8YamlEmitter emitter, (T1, T2, T3, T4, T5) value, YamlSerializationContext context)
         {
-            emitter.BeginSequence();
+            emitter.BeginSequence(SequenceStyle.Flow);
             context.Serialize(ref emitter, value.Item1);
             context.Serialize(ref emitter, value.Item2);
             context.Serialize(ref emitter, value.Item3);
@@ -143,7 +143,7 @@ namespace VYaml.Serialization
     {
         public void Serialize(ref Utf8YamlEmitter emitter, (T1, T2, T3, T4, T5, T6) value, YamlSerializationContext context)
         {
-            emitter.BeginSequence();
+            emitter.BeginSequence(SequenceStyle.Flow);
             context.Serialize(ref emitter, value.Item1);
             context.Serialize(ref emitter, value.Item2);
             context.Serialize(ref emitter, value.Item3);
@@ -176,7 +176,7 @@ namespace VYaml.Serialization
     {
         public void Serialize(ref Utf8YamlEmitter emitter, (T1, T2, T3, T4, T5, T6, T7) value, YamlSerializationContext context)
         {
-            emitter.BeginSequence();
+            emitter.BeginSequence(SequenceStyle.Flow);
             context.Serialize(ref emitter, value.Item1);
             context.Serialize(ref emitter, value.Item2);
             context.Serialize(ref emitter, value.Item3);
@@ -212,7 +212,7 @@ namespace VYaml.Serialization
     {
         public void Serialize(ref Utf8YamlEmitter emitter, ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest> value, YamlSerializationContext context)
         {
-            emitter.BeginSequence();
+            emitter.BeginSequence(SequenceStyle.Flow);
             context.Serialize(ref emitter, value.Item1);
             context.Serialize(ref emitter, value.Item2);
             context.Serialize(ref emitter, value.Item3);

--- a/VYaml.Unity/Assets/VYaml/Runtime/Serialization/Formatters/TupleFormatter.cs
+++ b/VYaml.Unity/Assets/VYaml/Runtime/Serialization/Formatters/TupleFormatter.cs
@@ -14,7 +14,7 @@ namespace VYaml.Serialization
                 return;
             }
 
-            emitter.BeginSequence();
+            emitter.BeginSequence(SequenceStyle.Flow);
             context.Serialize(ref emitter, value.Item1);
             emitter.EndSequence();
         }
@@ -43,7 +43,7 @@ namespace VYaml.Serialization
                 return;
             }
 
-            emitter.BeginSequence();
+            emitter.BeginSequence(SequenceStyle.Flow);
             context.Serialize(ref emitter, value.Item1);
             context.Serialize(ref emitter, value.Item2);
             emitter.EndSequence();
@@ -74,7 +74,7 @@ namespace VYaml.Serialization
                 return;
             }
 
-            emitter.BeginSequence();
+            emitter.BeginSequence(SequenceStyle.Flow);
             context.Serialize(ref emitter, value.Item1);
             context.Serialize(ref emitter, value.Item2);
             context.Serialize(ref emitter, value.Item3);
@@ -107,7 +107,7 @@ namespace VYaml.Serialization
                 return;
             }
 
-            emitter.BeginSequence();
+            emitter.BeginSequence(SequenceStyle.Flow);
             context.Serialize(ref emitter, value.Item1);
             context.Serialize(ref emitter, value.Item2);
             context.Serialize(ref emitter, value.Item3);
@@ -143,7 +143,7 @@ namespace VYaml.Serialization
                 return;
             }
 
-            emitter.BeginSequence();
+            emitter.BeginSequence(SequenceStyle.Flow);
             context.Serialize(ref emitter, value.Item1);
             context.Serialize(ref emitter, value.Item2);
             context.Serialize(ref emitter, value.Item3);
@@ -181,7 +181,7 @@ namespace VYaml.Serialization
                 return;
             }
 
-            emitter.BeginSequence();
+            emitter.BeginSequence(SequenceStyle.Flow);
             context.Serialize(ref emitter, value.Item1);
             context.Serialize(ref emitter, value.Item2);
             context.Serialize(ref emitter, value.Item3);
@@ -220,7 +220,7 @@ namespace VYaml.Serialization
                 return;
             }
 
-            emitter.BeginSequence();
+            emitter.BeginSequence(SequenceStyle.Flow);
             context.Serialize(ref emitter, value.Item1);
             context.Serialize(ref emitter, value.Item2);
             context.Serialize(ref emitter, value.Item3);
@@ -262,7 +262,7 @@ namespace VYaml.Serialization
                 return;
             }
 
-            emitter.BeginSequence();
+            emitter.BeginSequence(SequenceStyle.Flow);
             context.Serialize(ref emitter, value.Item1);
             context.Serialize(ref emitter, value.Item2);
             context.Serialize(ref emitter, value.Item3);

--- a/VYaml.Unity/Assets/VYaml/Runtime/Serialization/Formatters/ValueTupleFormatter.cs
+++ b/VYaml.Unity/Assets/VYaml/Runtime/Serialization/Formatters/ValueTupleFormatter.cs
@@ -8,7 +8,7 @@ namespace VYaml.Serialization
     {
         public void Serialize(ref Utf8YamlEmitter emitter, ValueTuple<T1> value, YamlSerializationContext context)
         {
-            emitter.BeginSequence();
+            emitter.BeginSequence(SequenceStyle.Flow);
             context.Serialize(ref emitter, value.Item1);
             emitter.EndSequence();
         }
@@ -31,7 +31,7 @@ namespace VYaml.Serialization
     {
         public void Serialize(ref Utf8YamlEmitter emitter, (T1, T2) value, YamlSerializationContext context)
         {
-            emitter.BeginSequence();
+            emitter.BeginSequence(SequenceStyle.Flow);
             context.Serialize(ref emitter, value.Item1);
             context.Serialize(ref emitter, value.Item2);
             emitter.EndSequence();
@@ -56,7 +56,7 @@ namespace VYaml.Serialization
     {
         public void Serialize(ref Utf8YamlEmitter emitter, (T1, T2, T3) value, YamlSerializationContext context)
         {
-            emitter.BeginSequence();
+            emitter.BeginSequence(SequenceStyle.Flow);
             context.Serialize(ref emitter, value.Item1);
             context.Serialize(ref emitter, value.Item2);
             context.Serialize(ref emitter, value.Item3);
@@ -83,7 +83,7 @@ namespace VYaml.Serialization
     {
         public void Serialize(ref Utf8YamlEmitter emitter, (T1, T2, T3, T4) value, YamlSerializationContext context)
         {
-            emitter.BeginSequence();
+            emitter.BeginSequence(SequenceStyle.Flow);
             context.Serialize(ref emitter, value.Item1);
             context.Serialize(ref emitter, value.Item2);
             context.Serialize(ref emitter, value.Item3);
@@ -112,7 +112,7 @@ namespace VYaml.Serialization
     {
         public void Serialize(ref Utf8YamlEmitter emitter, (T1, T2, T3, T4, T5) value, YamlSerializationContext context)
         {
-            emitter.BeginSequence();
+            emitter.BeginSequence(SequenceStyle.Flow);
             context.Serialize(ref emitter, value.Item1);
             context.Serialize(ref emitter, value.Item2);
             context.Serialize(ref emitter, value.Item3);
@@ -143,7 +143,7 @@ namespace VYaml.Serialization
     {
         public void Serialize(ref Utf8YamlEmitter emitter, (T1, T2, T3, T4, T5, T6) value, YamlSerializationContext context)
         {
-            emitter.BeginSequence();
+            emitter.BeginSequence(SequenceStyle.Flow);
             context.Serialize(ref emitter, value.Item1);
             context.Serialize(ref emitter, value.Item2);
             context.Serialize(ref emitter, value.Item3);
@@ -176,7 +176,7 @@ namespace VYaml.Serialization
     {
         public void Serialize(ref Utf8YamlEmitter emitter, (T1, T2, T3, T4, T5, T6, T7) value, YamlSerializationContext context)
         {
-            emitter.BeginSequence();
+            emitter.BeginSequence(SequenceStyle.Flow);
             context.Serialize(ref emitter, value.Item1);
             context.Serialize(ref emitter, value.Item2);
             context.Serialize(ref emitter, value.Item3);
@@ -212,7 +212,7 @@ namespace VYaml.Serialization
     {
         public void Serialize(ref Utf8YamlEmitter emitter, ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest> value, YamlSerializationContext context)
         {
-            emitter.BeginSequence();
+            emitter.BeginSequence(SequenceStyle.Flow);
             context.Serialize(ref emitter, value.Item1);
             context.Serialize(ref emitter, value.Item2);
             context.Serialize(ref emitter, value.Item3);


### PR DESCRIPTION
`Serialize(("item1", "item2"))`

## Before

```yaml
- item1
- item2
```

## After

```yaml
[item1, item2]
```