### PR TITLE
feat: add string quote style options to YamlEmitOptions

### DIFF
--- a/VYaml.Tests/Emitter/Utf8YamlEmitterTest.cs
+++ b/VYaml.Tests/Emitter/Utf8YamlEmitterTest.cs
@@ -1444,6 +1444,34 @@ namespace VYaml.Tests.Emitter
             ));
         }
 
+        [Test]
+        public void SingleQuotedEmitterSettings()
+        {
+            var emitter = CreateEmitter(new YamlEmitOptions { StringQuoteStyle = ScalarStyle.SingleQuoted });
+            emitter.BeginSequence();
+            {
+                emitter.WriteString("aaa\nbbb");
+                emitter.WriteString("aaa\tbbb");
+                emitter.WriteString("aaa'bbb");
+                emitter.WriteString("\0");
+                emitter.WriteString("\x8");
+                emitter.WriteString("\xA0");
+                emitter.WriteString("\x2028");
+                emitter.WriteString("\x1F");
+            }
+            emitter.EndSequence();
+            Assert.That(ToString(in emitter), Is.EqualTo(
+                "- 'aaa\nbbb'\n" +
+                "- 'aaa\tbbb'\n" +
+                "- 'aaa''bbb'\n" +
+                "- '\\0'\n" +
+                "- '\\b'\n" +
+                "- '\\_'\n" +
+                "- '\\L'\n" +
+                "- '\\u001f'\n"
+            ));
+        }
+
         static Utf8YamlEmitter CreateEmitter(YamlEmitOptions? options = null)
         {
             var bufferWriter = new ArrayBufferWriter<byte>(256);

--- a/VYaml.Unity/Assets/Tests/Emitter/Utf8YamlEmitterTest.cs
+++ b/VYaml.Unity/Assets/Tests/Emitter/Utf8YamlEmitterTest.cs
@@ -1444,6 +1444,34 @@ namespace VYaml.Tests.Emitter
             ));
         }
 
+        [Test]
+        public void SingleQuotedEmitterSettings()
+        {
+            var emitter = CreateEmitter(new YamlEmitOptions { StringQuoteStyle = ScalarStyle.SingleQuoted });
+            emitter.BeginSequence();
+            {
+                emitter.WriteString("aaa\nbbb");
+                emitter.WriteString("aaa\tbbb");
+                emitter.WriteString("aaa'bbb");
+                emitter.WriteString("\0");
+                emitter.WriteString("\x8");
+                emitter.WriteString("\xA0");
+                emitter.WriteString("\x2028");
+                emitter.WriteString("\x1F");
+            }
+            emitter.EndSequence();
+            Assert.That(ToString(in emitter), Is.EqualTo(
+                "- 'aaa\nbbb'\n" +
+                "- 'aaa\tbbb'\n" +
+                "- 'aaa''bbb'\n" +
+                "- '\\0'\n" +
+                "- '\\b'\n" +
+                "- '\\_'\n" +
+                "- '\\L'\n" +
+                "- '\\u001f'\n"
+            ));
+        }
+
         static Utf8YamlEmitter CreateEmitter(YamlEmitOptions? options = null)
         {
             var bufferWriter = new ArrayBufferWriter<byte>(256);

--- a/VYaml.Unity/Assets/VYaml/Runtime/Emitter/Utf8YamlEmitter.cs
+++ b/VYaml.Unity/Assets/VYaml/Runtime/Emitter/Utf8YamlEmitter.cs
@@ -613,7 +613,7 @@ namespace VYaml.Emitter
             if (style == ScalarStyle.Any)
             {
                 var analyzeInfo = EmitStringAnalyzer.Analyze(value);
-                style = analyzeInfo.SuggestScalarStyle();
+                style = analyzeInfo.SuggestScalarStyle(options);
             }
 
             switch (style)

--- a/VYaml.Unity/Assets/VYaml/Runtime/Emitter/YamlEmitOptions.cs
+++ b/VYaml.Unity/Assets/VYaml/Runtime/Emitter/YamlEmitOptions.cs
@@ -28,6 +28,22 @@ namespace VYaml.Emitter
         public static readonly YamlEmitOptions Default = new();
 
         public int IndentWidth { get; set; } = 2;
+
+        private ScalarStyle stringQuoteStyle = ScalarStyle.DoubleQuoted;
+
+        public ScalarStyle StringQuoteStyle
+        {
+            get => stringQuoteStyle;
+            set
+            {
+                if (value != ScalarStyle.SingleQuoted &&
+                    value != ScalarStyle.DoubleQuoted)
+                {
+                    throw new System.InvalidOperationException("Invalid scalar style");
+                }
+
+                stringQuoteStyle = value;
+            }
+        }
     }
 }
-

--- a/VYaml.Unity/Assets/VYaml/Runtime/Internal/EmitStringAnalyzer.cs
+++ b/VYaml.Unity/Assets/VYaml/Runtime/Internal/EmitStringAnalyzer.cs
@@ -19,13 +19,13 @@ namespace VYaml.Internal
             IsReservedWord = isReservedWord;
         }
 
-        public ScalarStyle SuggestScalarStyle()
+        public ScalarStyle SuggestScalarStyle(YamlEmitOptions options)
         {
-            if (Lines <= 1)
-            {
-                return NeedsQuotes ? ScalarStyle.DoubleQuoted : ScalarStyle.Plain;
-            }
-            return ScalarStyle.Literal;
+            return Lines <= 1
+                ? NeedsQuotes
+                    ? options.StringQuoteStyle
+                    : ScalarStyle.Plain
+                : ScalarStyle.Literal;
         }
     }
 
@@ -99,7 +99,7 @@ namespace VYaml.Internal
             {
                 lines--;
             }
-            return new EmitStringInfo(lines, needsQuotes || numbers == chars.Length, isReservedWord);
+            return new EmitStringInfo(lines, needsQuotes || numbers == value.Length, isReservedWord);
         }
 
         internal static StringBuilder BuildLiteralScalar(ReadOnlySpan<char> originalValue, int indentCharCount)

--- a/VYaml/Emitter/Utf8YamlEmitter.cs
+++ b/VYaml/Emitter/Utf8YamlEmitter.cs
@@ -613,7 +613,7 @@ namespace VYaml.Emitter
             if (style == ScalarStyle.Any)
             {
                 var analyzeInfo = EmitStringAnalyzer.Analyze(value);
-                style = analyzeInfo.SuggestScalarStyle();
+                style = analyzeInfo.SuggestScalarStyle(options);
             }
 
             switch (style)

--- a/VYaml/Emitter/YamlEmitOptions.cs
+++ b/VYaml/Emitter/YamlEmitOptions.cs
@@ -28,6 +28,22 @@ namespace VYaml.Emitter
         public static readonly YamlEmitOptions Default = new();
 
         public int IndentWidth { get; set; } = 2;
+
+        private ScalarStyle stringQuoteStyle = ScalarStyle.DoubleQuoted;
+
+        public ScalarStyle StringQuoteStyle
+        {
+            get => stringQuoteStyle;
+            set
+            {
+                if (value != ScalarStyle.SingleQuoted &&
+                    value != ScalarStyle.DoubleQuoted)
+                {
+                    throw new System.InvalidOperationException("Invalid scalar style");
+                }
+
+                stringQuoteStyle = value;
+            }
+        }
     }
 }
-

--- a/VYaml/Internal/EmitStringAnalyzer.cs
+++ b/VYaml/Internal/EmitStringAnalyzer.cs
@@ -19,13 +19,13 @@ namespace VYaml.Internal
             IsReservedWord = isReservedWord;
         }
 
-        public ScalarStyle SuggestScalarStyle()
+        public ScalarStyle SuggestScalarStyle(YamlEmitOptions options)
         {
-            if (Lines <= 1)
-            {
-                return NeedsQuotes ? ScalarStyle.DoubleQuoted : ScalarStyle.Plain;
-            }
-            return ScalarStyle.Literal;
+            return Lines <= 1
+                ? NeedsQuotes
+                    ? options.StringQuoteStyle
+                    : ScalarStyle.Plain
+                : ScalarStyle.Literal;
         }
     }
 
@@ -99,7 +99,7 @@ namespace VYaml.Internal
             {
                 lines--;
             }
-            return new EmitStringInfo(lines, needsQuotes || numbers == chars.Length, isReservedWord);
+            return new EmitStringInfo(lines, needsQuotes || numbers == value.Length, isReservedWord);
         }
 
         internal static StringBuilder BuildLiteralScalar(ReadOnlySpan<char> originalValue, int indentCharCount)


### PR DESCRIPTION
- gives greater flexibility in determining the default string quotes when values require it.
- fixed a broken reference to `char` in `EmitStringAnalyzer.Analyze()`