### PR TITLE
Fix ConsumeBom

### DIFF
--- a/VYaml.Unity/Assets/VYaml/Runtime/Parser/Utf8YamlTokenizer.cs
+++ b/VYaml.Unity/Assets/VYaml/Runtime/Parser/Utf8YamlTokenizer.cs
@@ -300,7 +300,7 @@ namespace VYaml.Parser
             tokens.Enqueue(new Token(TokenType.StreamEnd));
         }
 
-        void ConsumeBom()
+        bool ConsumeBom()
         {
             if (reader.IsNext(YamlCodes.Utf8Bom))
             {
@@ -324,7 +324,11 @@ namespace VYaml.Parser
                         throw new YamlTokenizerException(CurrentMark, "BOM must be at the beginning of the stream or document.");
                     }
                 }
+                return true;
             }
+
+            // not BOM.
+            return false;
         }
 
         void ConsumeDirective()
@@ -1482,7 +1486,7 @@ namespace VYaml.Parser
                         }
                         break;
                     case 0xEF:
-                        ConsumeBom();
+                        if (!ConsumeBom()) return;
                         break;
                     default:
                         return;

--- a/VYaml/Parser/Utf8YamlTokenizer.cs
+++ b/VYaml/Parser/Utf8YamlTokenizer.cs
@@ -300,7 +300,7 @@ namespace VYaml.Parser
             tokens.Enqueue(new Token(TokenType.StreamEnd));
         }
 
-        void ConsumeBom()
+        bool ConsumeBom()
         {
             if (reader.IsNext(YamlCodes.Utf8Bom))
             {
@@ -324,7 +324,11 @@ namespace VYaml.Parser
                         throw new YamlTokenizerException(CurrentMark, "BOM must be at the beginning of the stream or document.");
                     }
                 }
+                return true;
             }
+
+            // not BOM.
+            return false;
         }
 
         void ConsumeDirective()
@@ -1482,7 +1486,7 @@ namespace VYaml.Parser
                         }
                         break;
                     case 0xEF:
-                        ConsumeBom();
+                        if (!ConsumeBom()) return;
                         break;
                     default:
                         return;


### PR DESCRIPTION
I think it's the same bug as #120, An infinite loop occurred when a specific character was included.
The cause was that the BOM check (0xEF) in the `Utf8YamlTokenizer.SkipToNextToken` (`Utf8YamlTokenizer.ConsumeBom`) was not working properly.
Therefore, I have fixed the BOM check.
Please confirm this is correct.