### PR TITLE
Fix SourceGenerator generated code for netstandard2.0 env

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   test-dotnet:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   test-dotnet:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v3

--- a/VYaml.SourceGenerator/Emitter.cs
+++ b/VYaml.SourceGenerator/Emitter.cs
@@ -169,9 +169,12 @@ static class Emitter
             using (codeWriter.BeginBlockScope($"partial {typeDeclarationKeyword} {typeMeta.TypeName}"))
             {
                 // EmitCCtor(typeMeta, codeWriter, in context);
-                if (!TryEmitRegisterMethod(typeMeta, codeWriter, in context))
+                if (typeMeta.Symbol.TypeKind != TypeKind.Interface)
                 {
-                    return false;
+                    if (!TryEmitRegisterMethod(typeMeta, codeWriter, in context))
+                    {
+                        return false;
+                    }
                 }
                 if (!TryEmitFormatter(typeMeta, codeWriter, references, in context))
                 {

--- a/VYaml.Tests/VYaml.Tests.csproj
+++ b/VYaml.Tests/VYaml.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net9.0</TargetFramework>
+        <TargetFrameworks>net9.0;net48</TargetFrameworks>
 		<LangVersion>12</LangVersion>
         <Nullable>enable</Nullable>
         <ImplicitUsings>disable</ImplicitUsings>
@@ -29,7 +29,7 @@
         <!--<ProjectReference Include="..\VYaml.SourceGenerator\VYaml.SourceGenerator.csproj" />-->
 
 		<!-- disable SourceGenerator for net framework because it does not allow default implementations for interfaces -->
-        <ProjectReference Include="..\VYaml.SourceGenerator\VYaml.SourceGenerator.csproj" Condition="'$(TargetFramework)' != 'net472'">
+        <ProjectReference Include="..\VYaml.SourceGenerator\VYaml.SourceGenerator.csproj">
             <OutputItemType>Analyzer</OutputItemType>
             <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
         </ProjectReference>

--- a/VYaml.Tests/VYaml.Tests.csproj
+++ b/VYaml.Tests/VYaml.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net9.0;net472</TargetFrameworks>
+        <TargetFramework>net9.0</TargetFramework>
 		<LangVersion>12</LangVersion>
         <Nullable>enable</Nullable>
         <ImplicitUsings>disable</ImplicitUsings>
@@ -27,7 +27,7 @@
     <ItemGroup>
         <ProjectReference Include="..\VYaml\VYaml.csproj" />
         <!--<ProjectReference Include="..\VYaml.SourceGenerator\VYaml.SourceGenerator.csproj" />-->
-		
+
 		<!-- disable SourceGenerator for net framework because it does not allow default implementations for interfaces -->
         <ProjectReference Include="..\VYaml.SourceGenerator\VYaml.SourceGenerator.csproj" Condition="'$(TargetFramework)' != 'net472'">
             <OutputItemType>Analyzer</OutputItemType>

--- a/VYaml.Tests/VYaml.Tests.csproj
+++ b/VYaml.Tests/VYaml.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net9.0;net48</TargetFrameworks>
+        <TargetFramework>net9.0</TargetFramework>
 		<LangVersion>12</LangVersion>
         <Nullable>enable</Nullable>
         <ImplicitUsings>disable</ImplicitUsings>

--- a/VYaml/Serialization/Resolvers/GeneratedResolver.cs
+++ b/VYaml/Serialization/Resolvers/GeneratedResolver.cs
@@ -31,7 +31,7 @@ namespace VYaml.Serialization
 
             if (type.IsInterface)
             {
-                var generatedFormatterType = Type.GetType($"{type.FullName}GeneratedFormatter");
+                var generatedFormatterType = type.GetNestedType($"{type.Name}GeneratedFormatter");
                 if (generatedFormatterType == null) return false;
 
                 var formatterInstance = (IYamlFormatter<T>)Activator.CreateInstance(generatedFormatterType)!;

--- a/VYaml/Serialization/Resolvers/GeneratedResolver.cs
+++ b/VYaml/Serialization/Resolvers/GeneratedResolver.cs
@@ -20,24 +20,32 @@ namespace VYaml.Serialization
             {
                 if (Check<T>.Registered) return;
 
-                var type = typeof(T);
-                TryInvokeRegisterYamlFormatter(type);
+                TryInvokeRegisterYamlFormatter<T>();
             }
         }
 
-        static bool TryInvokeRegisterYamlFormatter(Type type)
+        static bool TryInvokeRegisterYamlFormatter<T>()
         {
+            var type = typeof(T);
             if (type.GetCustomAttribute<YamlObjectAttribute>() == null) return false;
+
+            if (type.IsInterface)
+            {
+                var generatedFormatterType = Type.GetType($"{type.FullName}GeneratedFormatter");
+                if (generatedFormatterType == null) return false;
+
+                var formatterInstance = (IYamlFormatter<T>)Activator.CreateInstance(generatedFormatterType)!;
+                Register(formatterInstance);
+
+                return true;
+            }
 
             var m = type.GetMethod("__RegisterVYamlFormatter",
                 BindingFlags.Public |
                 BindingFlags.NonPublic |
                 BindingFlags.Static);
 
-            if (m == null)
-            {
-                return false;
-            }
+            if (m == null) return false;
 
             m.Invoke(null, null); // Cache<T>.formatter will set from method
             return true;


### PR DESCRIPTION
#143 

The problem is that the __RegisterVYamlFormatter static method has been added under the interface. This does not seem to be supported by the .NET Framework runtime.

```cs
     partial interface IUnion
     {
         [VYaml.Annotations.Preserve]
         public static void __RegisterVYamlFormatter()
         {
             global::VYaml.Serialization.GeneratedResolver.Register(new IUnionGeneratedFormatter());
         }
```