### PR TITLE
Fix multiple parser issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,6 +265,57 @@ documents[1]["Warning"] // #=> "A slightly different error message."
 documents[2]["Fatal"]   // #=> "Unknown variable \"bar\""
 ```
 
+#### Ignore null/default values
+
+By default, VYaml serializes all properties, including those with null or default values. You can change this behavior using `YamlSerializerOptions.DefaultIgnoreCondition`:
+
+```cs
+var options = new YamlSerializerOptions
+{
+    DefaultIgnoreCondition = YamlIgnoreCondition.WhenWritingNull
+};
+
+var obj = new Person
+{
+    Name = "John",
+    Age = 30,
+    Email = null,  // This will be ignored
+    Address = null  // This will be ignored
+};
+
+YamlSerializer.Serialize(obj, options);
+// Output:
+// name: John
+// age: 30
+```
+
+Available options:
+- `YamlIgnoreCondition.Never` - Always serialize all properties (default)
+- `YamlIgnoreCondition.WhenWritingNull` - Skip properties with null values
+- `YamlIgnoreCondition.WhenWritingDefault` - Skip properties with default values (null for reference types, 0 for numbers, false for bool, etc.)
+
+Example with `WhenWritingDefault`:
+```cs
+var options = new YamlSerializerOptions
+{
+    DefaultIgnoreCondition = YamlIgnoreCondition.WhenWritingDefault
+};
+
+var obj = new Person
+{
+    Name = "John",
+    Age = 0,        // This will be ignored (default for int)
+    IsActive = false,  // This will be ignored (default for bool)
+    Email = null,   // This will be ignored (default for string)
+    Score = 100     // This will be serialized
+};
+
+YamlSerializer.Serialize(obj, options);
+// Output:
+// name: John
+// score: 100
+```
+
 #### Naming convention
 
 :exclamation: By default, VYaml maps C# property names in lower camel case (e.g. `propertyName`) format to yaml keys.

--- a/VYaml.Benchmark/VYaml.Benchmark.csproj
+++ b/VYaml.Benchmark/VYaml.Benchmark.csproj
@@ -11,7 +11,7 @@
     <ItemGroup>
       <PackageReference Include="BenchmarkDotNet" Version="0.13.1" />
       <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
-      <PackageReference Include="System.Text.Json" Version="8.0.4" />
+      <PackageReference Include="System.Text.Json" Version="9.0.6" />
       <PackageReference Include="YamlDotNet" Version="11.2.1" />
     </ItemGroup>
 

--- a/VYaml.SourceGenerator/SymbolExtensions.cs
+++ b/VYaml.SourceGenerator/SymbolExtensions.cs
@@ -6,26 +6,26 @@ namespace VYaml.SourceGenerator;
 
 static class SymbolExtensions
 {
-    public static bool ContainsAttribute(this ISymbol symbol, INamedTypeSymbol attribtue)
+    public static bool ContainsAttribute(this ISymbol symbol, INamedTypeSymbol attribute)
     {
-        return symbol.GetAttributes().Any(x => SymbolEqualityComparer.Default.Equals(x.AttributeClass, attribtue));
+        return symbol.GetAttributes().Any(x => SymbolEqualityComparer.Default.Equals(x.AttributeClass, attribute));
     }
 
-    public static AttributeData? GetAttribute(this ISymbol symbol, INamedTypeSymbol attribtue)
+    public static AttributeData? GetAttribute(this ISymbol symbol, INamedTypeSymbol attribute)
     {
-        return symbol.GetAttributes().FirstOrDefault(x => SymbolEqualityComparer.Default.Equals(x.AttributeClass, attribtue));
+        return symbol.GetAttributes().FirstOrDefault(x => SymbolEqualityComparer.Default.Equals(x.AttributeClass, attribute));
     }
 
-    public static AttributeData? GetImplAttribute(this ISymbol symbol, INamedTypeSymbol implAttribtue)
+    public static AttributeData? GetImplAttribute(this ISymbol symbol, INamedTypeSymbol implAttribute)
     {
         return symbol.GetAttributes().FirstOrDefault(x =>
         {
             if (x.AttributeClass == null) return false;
-            if (x.AttributeClass.EqualsUnconstructedGenericType(implAttribtue)) return true;
+            if (x.AttributeClass.EqualsUnconstructedGenericType(implAttribute)) return true;
 
             foreach (var item in x.AttributeClass.GetAllBaseTypes())
             {
-                if (item.EqualsUnconstructedGenericType(implAttribtue))
+                if (item.EqualsUnconstructedGenericType(implAttribute))
                 {
                     return true;
                 }

--- a/VYaml.Tests/Emitter/CommentEmitterTest.cs
+++ b/VYaml.Tests/Emitter/CommentEmitterTest.cs
@@ -1,0 +1,395 @@
+using System.Buffers;
+using System.Text;
+using NUnit.Framework;
+using VYaml.Emitter;
+
+namespace VYaml.Tests.Emitter
+{
+    /// <summary>
+    /// A test suite for validating the behaviour of comment emission in YAML using Utf8YamlEmitter.
+    /// </summary>
+    /// <remarks>
+    /// This class contains test methods that ensure comments can be emitted in various contexts,
+    /// such as at the start of a document, between mapping entries, inside sequences,
+    /// and other scenarios. These tests validate compliance with YAML formatting rules and
+    /// expected output when comments are either enabled or disabled.
+    /// </remarks>
+    [TestFixture]
+    public class CommentEmitterTest
+    {
+        /// <summary>
+        /// Tests the ability of the YAML emitter to correctly emit a comment
+        /// at the very start of a YAML document before any content is defined.
+        /// </summary>
+        /// <remarks>
+        /// This test verifies that a top-level comment can be emitted as the first
+        /// element of a YAML document, ensuring appropriate formatting and adherence
+        /// to YAML specifications. It also checks the integration between options
+        /// such as PreserveComments and the emitted output format.
+        /// </remarks>
+        /// <exception cref="AssertionException">
+        /// Thrown when the emitted YAML document does not match the expected output
+        /// string, indicating a failure in comment emission or formatting logic.
+        /// </exception>
+        [Test]
+        public void EmitComment_AtDocumentStart()
+        {
+            var writer = new ArrayBufferWriter<byte>();
+            var options = new YamlEmitOptions { PreserveComments = true };
+            var emitter = new Utf8YamlEmitter(writer, options);
+            
+            emitter.WriteComment("This is a document header comment");
+            emitter.BeginMapping();
+            emitter.WriteString("key");
+            emitter.WriteString("value");
+            emitter.EndMapping();
+            
+            var yaml = Encoding.UTF8.GetString(writer.WrittenSpan);
+            Assert.That(yaml, Is.EqualTo("# This is a document header comment\nkey: value\n"));
+        }
+
+        /// <summary>
+        /// Tests the ability of the YAML emitter to correctly emit a comment
+        /// between two mapping entries in a YAML document.
+        /// </summary>
+        /// <remarks>
+        /// This test validates the proper placement and formatting of comments
+        /// within YAML mappings when the PreserveComments option is enabled. It
+        /// ensures that a comment can be emitted between two key-value pairs
+        /// without breaking document structure or formatting rules.
+        /// </remarks>
+        /// <exception cref="AssertionException">
+        /// Thrown when the resulting YAML output does not include the comment in
+        /// the expected position or when the output differs from the formatted standard.
+        /// </exception>
+        [Test]
+        public void EmitComment_BetweenMappingEntries()
+        {
+            var writer = new ArrayBufferWriter<byte>();
+            var options = new YamlEmitOptions { PreserveComments = true };
+            var emitter = new Utf8YamlEmitter(writer, options);
+            
+            emitter.BeginMapping();
+            emitter.WriteString("key1");
+            emitter.WriteString("value1");
+            emitter.WriteComment("Comment between entries");
+            emitter.WriteString("key2");
+            emitter.WriteString("value2");
+            emitter.EndMapping();
+            
+            var yaml = Encoding.UTF8.GetString(writer.WrittenSpan);
+            Assert.That(yaml, Is.EqualTo("key1: value1\n# Comment between entries\nkey2: value2\n"));
+        }
+
+        /// <summary>
+        /// Tests the emission of a comment within a YAML sequence using the Utf8YamlEmitter.
+        /// </summary>
+        /// <remarks>
+        /// This test validates the capability of the emitter to insert a comment inside a YAML sequence,
+        /// ensuring proper formatting and placement within the emitted output. It confirms that comments
+        /// are correctly written when PreserveComments is enabled and that the overall sequence structure
+        /// adheres to YAML specification with respect to indentation and line placement.
+        /// </remarks>
+        /// <exception cref="AssertionException">
+        /// Thrown when the emitted YAML document does not match the expected output, indicating issues
+        /// with the comment's integration into the sequence or formatting inconsistencies.
+        /// </exception>
+        [Test]
+        public void EmitComment_InSequence()
+        {
+            var writer = new ArrayBufferWriter<byte>();
+            var options = new YamlEmitOptions { PreserveComments = true };
+            var emitter = new Utf8YamlEmitter(writer, options);
+            
+            emitter.BeginSequence();
+            emitter.WriteString("item1");
+            emitter.WriteComment("Comment in sequence");
+            emitter.WriteString("item2");
+            emitter.EndSequence();
+            
+            var yaml = Encoding.UTF8.GetString(writer.WrittenSpan);
+            Assert.That(yaml, Is.EqualTo("- item1\n# Comment in sequence\n- item2\n"));
+        }
+
+        /// <summary>
+        /// Tests the emission of an empty comment within a YAML document using the Utf8YamlEmitter.
+        /// </summary>
+        /// <remarks>
+        /// This test ensures that an empty comment is correctly emitted as a standalone `#` symbol
+        /// within a YAML document. It verifies proper formatting when comments are explicitly enabled
+        /// through the <see cref="YamlEmitOptions.PreserveComments"/> option. The test also confirms
+        /// that empty comments do not interfere with surrounding mappings and values in the emitted YAML.
+        /// </remarks>
+        /// <exception cref="AssertionException">
+        /// Thrown when the emitted YAML output does not match the expected format, indicating a failure
+        /// in the empty comment handling or formatting logic.
+        /// </exception>
+        [Test]
+        public void EmitComment_EmptyComment()
+        {
+            var writer = new ArrayBufferWriter<byte>();
+            var options = new YamlEmitOptions { PreserveComments = true };
+            var emitter = new Utf8YamlEmitter(writer, options);
+            
+            emitter.BeginMapping();
+            emitter.WriteString("key");
+            emitter.WriteString("value");
+            emitter.WriteComment("");
+            emitter.WriteString("next");
+            emitter.WriteString("value2");
+            emitter.EndMapping();
+            
+            var yaml = Encoding.UTF8.GetString(writer.WrittenSpan);
+            Assert.That(yaml, Is.EqualTo("key: value\n#\nnext: value2\n"));
+        }
+
+        /// <summary>
+        /// Verifies the successful emission of a YAML comment when the comment begins with
+        /// a leading space, ensuring it adheres to YAML specifications and formatting.
+        /// </summary>
+        /// <remarks>
+        /// This test demonstrates that a comment with an intentional leading space is correctly
+        /// emitted, using the Utf8YamlEmitter with the PreserveComments option enabled. It also checks
+        /// that the emitted comment retains proper formatting, including the initial space after the comment marker (#).
+        /// </remarks>
+        /// <exception cref="AssertionException">
+        /// Thrown when the emitted YAML does not match the expected format,
+        /// indicating an issue with the comment emission logic or handling of leading spaces.
+        /// </exception>
+        [Test]
+        public void EmitComment_WithLeadingSpace()
+        {
+            var writer = new ArrayBufferWriter<byte>();
+            var options = new YamlEmitOptions { PreserveComments = true };
+            var emitter = new Utf8YamlEmitter(writer, options);
+            
+            emitter.WriteComment(" Comment with leading space");
+            
+            var yaml = Encoding.UTF8.GetString(writer.WrittenSpan);
+            Assert.That(yaml, Is.EqualTo("#  Comment with leading space\n"));
+        }
+
+        /// <summary>
+        /// Tests the emission of a YAML comment without a leading space.
+        /// </summary>
+        /// <remarks>
+        /// This test ensures that the Utf8YamlEmitter correctly emits a comment
+        /// that begins immediately after the "#" character, without an additional
+        /// leading space. The functionality is validated with the PreserveComments
+        /// option enabled in the YamlEmitOptions configuration.
+        /// </remarks>
+        /// <exception cref="AssertionException">
+        /// Thrown when the output YAML string does not match the expected result,
+        /// indicating an issue with the comment formatting or emission logic.
+        /// </exception>
+        [Test]
+        public void EmitComment_WithoutLeadingSpace()
+        {
+            var writer = new ArrayBufferWriter<byte>();
+            var options = new YamlEmitOptions { PreserveComments = true };
+            var emitter = new Utf8YamlEmitter(writer, options);
+            
+            emitter.WriteComment("Comment without leading space");
+            
+            var yaml = Encoding.UTF8.GetString(writer.WrittenSpan);
+            Assert.That(yaml, Is.EqualTo("# Comment without leading space\n"));
+        }
+
+        /// <summary>
+        /// Tests the behavior of the YAML emitter when comments are disabled via the YamlEmitOptions configuration.
+        /// </summary>
+        /// <remarks>
+        /// This test ensures that comments are not emitted in the output when the PreserveComments option
+        /// is set to false. It verifies that the resulting YAML document excludes any comments that
+        /// were attempted to be written, adhering strictly to the specified configuration.
+        /// </remarks>
+        /// <exception cref="AssertionException">
+        /// Thrown when the emitted YAML output includes a comment despite the PreserveComments option
+        /// being disabled, indicating a failure to respect the configuration or logic related to comment handling.
+        /// </exception>
+        [Test]
+        public void EmitComment_NotEmittedWhenDisabled()
+        {
+            var writer = new ArrayBufferWriter<byte>();
+            var options = new YamlEmitOptions { PreserveComments = false };
+            var emitter = new Utf8YamlEmitter(writer, options);
+            
+            emitter.WriteComment("This comment should not appear");
+            emitter.BeginMapping();
+            emitter.WriteString("key");
+            emitter.WriteString("value");
+            emitter.EndMapping();
+            
+            var yaml = Encoding.UTF8.GetString(writer.WrittenSpan);
+            Assert.That(yaml, Is.EqualTo("key: value\n"));
+        }
+
+        /// <summary>
+        /// Validates the emission of comments within nested YAML mapping structures.
+        /// </summary>
+        /// <remarks>
+        /// This test ensures that comments are correctly emitted both before and inside
+        /// nested mappings within a YAML document. It verifies that the comments are
+        /// placed in the appropriate locations relative to the mapping elements and
+        /// adhere to YAML formatting rules when comment preservation is enabled.
+        /// </remarks>
+        /// <exception cref="AssertionException">
+        /// Thrown when the generated YAML output does not match the expected format.
+        /// This could indicate an issue with comment placement, formatting, or
+        /// preservation logic in nested structures.
+        /// </exception>
+        [Test]
+        public void EmitComment_NestedStructures()
+        {
+            var writer = new ArrayBufferWriter<byte>();
+            var options = new YamlEmitOptions { PreserveComments = true };
+            var emitter = new Utf8YamlEmitter(writer, options);
+            
+            emitter.BeginMapping();
+            emitter.WriteString("outer");
+            emitter.WriteComment("Before nested mapping");
+            emitter.BeginMapping();
+            emitter.WriteComment("Inside nested mapping");
+            emitter.WriteString("inner");
+            emitter.WriteString("value");
+            emitter.EndMapping();
+            emitter.EndMapping();
+            
+            var yaml = Encoding.UTF8.GetString(writer.WrittenSpan);
+            const string expected = """
+                                    outer:
+                                      # Before nested mapping
+                                      # Inside nested mapping
+                                      inner: value
+
+                                    """;
+            Assert.That(yaml, Is.EqualTo(expected));
+        }
+
+        /// <summary>
+        /// Verifies the ability of the Utf8YamlEmitter to correctly emit comments within a flow-style YAML sequence.
+        /// </summary>
+        /// <remarks>
+        /// This test evaluates the inclusion and formatting of inline comments in a flow sequence
+        /// where elements are organized in a comma-separated form within square brackets. It ensures
+        /// that comments are preserved and correctly positioned relative to the sequence elements
+        /// when the PreserveComments option is enabled. Special emphasis is placed on verifying
+        /// compliance with YAML specifications and the specific behavior of flow-style sequences
+        /// when comments are present.
+        /// </remarks>
+        /// <exception cref="AssertionException">
+        /// Thrown if the resulting YAML output does not meet the expected structure or formatting,
+        /// including the positioning or rendering of comments.
+        /// </exception>
+        [Test]
+        public void EmitComment_InFlowSequence()
+        {
+            var writer = new ArrayBufferWriter<byte>();
+            var options = new YamlEmitOptions { PreserveComments = true };
+            var emitter = new Utf8YamlEmitter(writer, options);
+            
+            emitter.BeginSequence(SequenceStyle.Flow);
+            emitter.WriteString("item1");
+            emitter.WriteComment("inline comment");
+            emitter.WriteString("item2");
+            emitter.EndSequence();
+            
+            var yaml = Encoding.UTF8.GetString(writer.WrittenSpan);
+            // Note: Comments in flow style should be handled differently
+            // This test documents the current behavior
+            Assert.That(yaml.Contains("[") && yaml.Contains("]"), Is.True);
+        }
+
+        /// <summary>
+        /// Verifies the ability of the YAML emitter to correctly emit multiple consecutive comments
+        /// within a document, ensuring adherence to expected formatting and comment order.
+        /// </summary>
+        /// <remarks>
+        /// This test checks the emission of multiple comments in sequence before other YAML content.
+        /// It validates that each comment is emitted on its own line with proper formatting,
+        /// and that subsequent document elements are emitted correctly after the comments.
+        /// </remarks>
+        /// <exception cref="AssertionException">
+        /// Thrown when the emitted YAML output does not include all expected comments
+        /// in the correct order or fails to match the specified formatting in the expected output.
+        /// </exception>
+        [Test]
+        public void EmitComment_MultipleConsecutive()
+        {
+            var writer = new ArrayBufferWriter<byte>();
+            var options = new YamlEmitOptions { PreserveComments = true };
+            var emitter = new Utf8YamlEmitter(writer, options);
+            
+            emitter.WriteComment("First comment");
+            emitter.WriteComment("Second comment");
+            emitter.WriteComment("Third comment");
+            emitter.BeginMapping();
+            emitter.WriteString("key");
+            emitter.WriteString("value");
+            emitter.EndMapping();
+            
+            var yaml = Encoding.UTF8.GetString(writer.WrittenSpan);
+            const string expected = """
+                                    # First comment
+                                    # Second comment
+                                    # Third comment
+                                    key: value
+
+                                    """;
+            Assert.That(yaml, Is.EqualTo(expected));
+        }
+
+        /// <summary>
+        /// Tests the ability of the YAML emitter to correctly emit a comment
+        /// containing special characters, ensuring proper encoding and output formatting.
+        /// </summary>
+        /// <remarks>
+        /// This test validates that the Utf8YamlEmitter can handle comments with a variety
+        /// of special characters, including punctuation, symbols, and YAML-like structures,
+        /// without errors or unexpected behavior. It ensures compliance with YAML syntax
+        /// and the correct preservation of such content.
+        /// </remarks>
+        /// <exception cref="AssertionException">
+        /// Thrown when the emitted YAML document's comment does not match the expected output,
+        /// indicating a failure in character handling or emission logic.
+        /// </exception>
+        [Test]
+        public void EmitComment_WithSpecialCharacters()
+        {
+            var writer = new ArrayBufferWriter<byte>();
+            var options = new YamlEmitOptions { PreserveComments = true };
+            var emitter = new Utf8YamlEmitter(writer, options);
+            
+            emitter.WriteComment("Special chars: !@#$%^&*() and YAML-like: key: value");
+            
+            var yaml = Encoding.UTF8.GetString(writer.WrittenSpan);
+            Assert.That(yaml, Is.EqualTo("# Special chars: !@#$%^&*() and YAML-like: key: value\n"));
+        }
+
+        /// <summary>
+        /// Ensures the Utf8YamlEmitter correctly emits comments containing Unicode characters,
+        /// including non-ASCII symbols and emojis, in the expected YAML format.
+        /// </summary>
+        /// <remarks>
+        /// This test verifies that Unicode characters are preserved and rendered accurately
+        /// in YAML comments when the PreserveComments option is enabled. It checks compatibility
+        /// in handling diverse character sets, ensuring compliance with UTF-8 encoding standards.
+        /// </remarks>
+        /// <exception cref="AssertionException">
+        /// Thrown when the emitted YAML document does not contain the expected Unicode comment,
+        /// indicating a failure in encoding, formatting, or comment emission logic.
+        /// </exception>
+        [Test]
+        public void EmitComment_WithUnicodeCharacters()
+        {
+            var writer = new ArrayBufferWriter<byte>();
+            var options = new YamlEmitOptions { PreserveComments = true };
+            var emitter = new Utf8YamlEmitter(writer, options);
+            
+            emitter.WriteComment("Unicode: 你好世界 🌍 émojis");
+            
+            var yaml = Encoding.UTF8.GetString(writer.WrittenSpan);
+            Assert.That(yaml, Is.EqualTo("# Unicode: 你好世界 🌍 émojis\n"));
+        }
+    }
+}

--- a/VYaml.Tests/Integration/CommentRoundTripTest.cs
+++ b/VYaml.Tests/Integration/CommentRoundTripTest.cs
@@ -1,0 +1,351 @@
+using System;
+using System.Buffers;
+using System.Collections.Generic;
+using System.Text;
+using NUnit.Framework;
+using VYaml.Emitter;
+using VYaml.Parser;
+
+namespace VYaml.Tests.Integration
+{
+    /// <summary>
+    /// Represents a set of test cases to ensure that YAML documents containing comments
+    /// can be accurately parsed and emitted without loss of content, structure, or formatting.
+    /// </summary>
+    /// <remarks>
+    /// This class contains tests that validate the round-tripping process of YAML documents,
+    /// particularly focusing on preserving comments within different types of YAML structures.
+    /// It includes tests for simple comments, comments in sequences, nested structures, empty comments, and
+    /// more complex YAML documents.
+    /// </remarks>
+    [TestFixture]
+    public class CommentRoundTripTest
+    {
+        /// <summary>
+        /// Verifies that YAML containing simple comments can be parsed and emitted back
+        /// while preserving both the comments and structural integrity of the document.
+        /// </summary>
+        [Test]
+        public void RoundTrip_SimpleComments()
+        {
+            const string originalYaml = """
+                                        # Header comment
+                                        key1: value1
+                                        # Mid-document comment
+                                        key2: value2
+                                        # Footer comment
+                                        """;
+
+            var roundTripYaml = RoundTripYaml(originalYaml);
+            Assert.That(NormalizeYaml(roundTripYaml), Is.EqualTo(NormalizeYaml(originalYaml)));
+        }
+
+        /// <summary>
+        /// Validates round-trip YAML serialization and deserialization by ensuring that comments within sequences
+        /// are preserved properly without altering their structure or position.
+        /// </summary>
+        [Test]
+        public void RoundTrip_CommentsInSequence()
+        {
+            const string originalYaml = """
+                                        items:
+                                          # First item comment
+                                          - item1
+                                          # Second item comment
+                                          - item2
+                                        """;
+
+            var roundTripYaml = RoundTripYaml(originalYaml);
+            Assert.That(NormalizeYaml(roundTripYaml), Is.EqualTo(NormalizeYaml(originalYaml)));
+        }
+
+        /// <summary>
+        /// Performs a round-trip test on YAML containing comments within a nested structure.
+        /// Verifies that the YAML structure and comments are preserved during parsing and emitting.
+        /// </summary>
+        [Test]
+        public void RoundTrip_CommentsInNestedStructure()
+        {
+            const string originalYaml = """
+                                        # Root comment
+                                        outer:
+                                          # Nested comment
+                                          inner:
+                                            # Deep comment
+                                            key: value
+                                        """;
+
+            var roundTripYaml = RoundTripYaml(originalYaml);
+            Assert.That(NormalizeYaml(roundTripYaml), Is.EqualTo(NormalizeYaml(originalYaml)));
+        }
+
+        /// <summary>
+        /// Verifies that YAML round-tripping preserves empty comment lines while maintaining the document's structure and content.
+        /// </summary>
+        [Test]
+        public void RoundTrip_EmptyComments()
+        {
+            const string originalYaml = """
+                                        key1: value1
+                                        #
+                                        key2: value2
+                                        """;
+
+            var roundTripYaml = RoundTripYaml(originalYaml);
+            Assert.That(NormalizeYaml(roundTripYaml), Is.EqualTo(NormalizeYaml(originalYaml)));
+        }
+
+        /// <summary>
+        /// Ensures the YAML serialization and deserialization process retains comments, structure, and formatting for complex documents.
+        /// </summary>
+        [Test]
+        public void RoundTrip_ComplexDocument()
+        {
+            const string originalYaml = """
+                                        # Application Configuration
+                                        # Version: 1.0
+
+                                        # Database settings
+                                        database:
+                                          # Connection string
+                                          connection: localhost:5432
+                                          # Pool size
+                                          pool_size: 10
+
+                                        # Feature flags
+                                        features:
+                                          # Enable new UI
+                                          - name: new_ui
+                                            enabled: true
+                                          # Beta features
+                                          - name: beta
+                                            enabled: false
+
+                                        # End of configuration
+                                        """;
+
+            var roundTripYaml = RoundTripYaml(originalYaml);
+            Assert.That(NormalizeYaml(roundTripYaml), Is.EqualTo(NormalizeYaml(originalYaml)));
+        }
+
+        /// <summary>
+        /// Parses and emits YAML content while preserving comments and their formatting.
+        /// Efficiently processes YAML data using manual event handling to extract and reconstruct its structure.
+        /// </summary>
+        [Test]
+        public void ParseAndEmit_ManualConstruction()
+        {
+            // Parse with comments
+            const string yaml = """
+                                # Header
+                                key: value
+                                # Footer
+                                """;
+            
+            var parserOptions = new YamlParserOptions { PreserveComments = true }; // Use default StripLeadingWhitespace = true
+            var parser = new YamlParser(new ReadOnlySequence<byte>(Encoding.UTF8.GetBytes(yaml)), parserOptions);
+            
+            // Emit with comments
+            var writer = new ArrayBufferWriter<byte>();
+            var emitOptions = new YamlEmitOptions { PreserveComments = true }; // Default AddLeadingSpace = true
+            var emitter = new Utf8YamlEmitter(writer, emitOptions);
+            
+            // Manually read and emit events
+            while (parser.Read())
+            {
+                switch (parser.CurrentEventType)
+                {
+                    case ParseEventType.StreamStart:
+                    case ParseEventType.StreamEnd:
+                        // Skip stream events
+                        break;
+                        
+                    case ParseEventType.DocumentStart:
+                    case ParseEventType.DocumentEnd:
+                        // Skip document events for simple case
+                        break;
+                        
+                    case ParseEventType.Comment:
+                        emitter.WriteComment(parser.GetScalarAsString());
+                        break;
+                        
+                    case ParseEventType.MappingStart:
+                        emitter.BeginMapping();
+                        break;
+                        
+                    case ParseEventType.MappingEnd:
+                        emitter.EndMapping();
+                        break;
+                        
+                    case ParseEventType.SequenceStart:
+                        emitter.BeginSequence();
+                        break;
+                        
+                    case ParseEventType.SequenceEnd:
+                        emitter.EndSequence();
+                        break;
+                        
+                    case ParseEventType.Scalar:
+                        emitter.WriteString(parser.GetScalarAsString() ?? throw new InvalidOperationException());
+                        break;
+                    default:
+                        throw new InvalidOperationException();
+                }
+            }
+            
+            var result = Encoding.UTF8.GetString(writer.WrittenSpan);
+            // With StripLeadingWhitespace = true, parser extracts "Header" and "Footer"
+            // With AddLeadingSpace = true, emitter adds space, resulting in "# Header" and "# Footer"
+            Assert.That(result.Contains("# Header"), Is.True);
+            Assert.That(result.Contains("# Footer"), Is.True);
+            Assert.That(result.Contains("key: value"), Is.True);
+        }
+
+        /// <summary>
+        /// Performs a round-trip operation on the provided YAML string, ensuring that comments
+        /// and formatting are preserved during serialization and deserialization.
+        /// </summary>
+        /// <param name="yaml">The input YAML string to be processed.</param>
+        /// <returns>A YAML string that has undergone a round-trip transformation while
+        /// maintaining its comments and structural integrity.</returns>
+        private static string RoundTripYaml(string yaml)
+        {
+            // Parse the YAML with comment preservation enabled and precise round-trip options
+            var parserOptions = new YamlParserOptions { PreserveComments = true, StripLeadingWhitespace = false };
+            var parser = new YamlParser(new ReadOnlySequence<byte>(Encoding.UTF8.GetBytes(yaml)), parserOptions);
+            
+            // Create emitter with comment preservation enabled and precise round-trip options
+            var writer = new ArrayBufferWriter<byte>();
+            var emitOptions = new YamlEmitOptions { PreserveComments = true, AddLeadingSpace = false };
+            var emitter = new Utf8YamlEmitter(writer, emitOptions);
+            
+            // Process all events
+            while (parser.Read())
+            {
+                switch (parser.CurrentEventType)
+                {
+                    case ParseEventType.StreamStart:
+                    case ParseEventType.StreamEnd:
+                        // Skip stream events
+                        break;
+                        
+                    case ParseEventType.DocumentStart:
+                    case ParseEventType.DocumentEnd:
+                        // Skip document events for simple round-trip
+                        break;
+                        
+                    case ParseEventType.Comment:
+                        emitter.WriteComment(parser.GetScalarAsString());
+                        break;
+                        
+                    case ParseEventType.MappingStart:
+                        emitter.BeginMapping();
+                        break;
+                        
+                    case ParseEventType.MappingEnd:
+                        emitter.EndMapping();
+                        break;
+                        
+                    case ParseEventType.SequenceStart:
+                        emitter.BeginSequence();
+                        break;
+                        
+                    case ParseEventType.SequenceEnd:
+                        emitter.EndSequence();
+                        break;
+                        
+                    case ParseEventType.Scalar:
+                        var value = parser.GetScalarAsString();
+                        if (value != null)
+                        {
+                            emitter.WriteString(value);
+                        }
+                        else
+                        {
+                            emitter.WriteNull();
+                        }
+                        break;
+                    default:
+                        throw new InvalidOperationException();
+                }
+            }
+            
+            return Encoding.UTF8.GetString(writer.WrittenSpan);
+        }
+
+        /// <summary>
+        /// Normalizes YAML by extracting semantic structure while ignoring formatting differences.
+        /// </summary>
+        /// <param name="yaml">The YAML document to normalize, provided as a string.</param>
+        /// <returns>A string that represents the normalized semantic structure of the YAML document.</returns>
+        private static string NormalizeYaml(string yaml)
+        {
+            // Parse both original and round-trip to extract semantic structure
+            var events = ExtractEvents(yaml);
+            return string.Join("\n", events);
+        }
+
+        /// <summary>
+        /// Extracts semantic events from a YAML document, including structural components and comments.
+        /// </summary>
+        /// <param name="yaml">The YAML document as a string from which to extract events.</param>
+        /// <returns>A list of strings representing the semantic events extracted from the YAML document.</returns>
+        private static List<string> ExtractEvents(string yaml)
+        {
+            var events = new List<string>();
+
+            try
+            {
+                var parserOptions = new YamlParserOptions { PreserveComments = true, StripLeadingWhitespace = false };
+                var parser = new YamlParser(new ReadOnlySequence<byte>(Encoding.UTF8.GetBytes(yaml)), parserOptions);
+                
+                while (parser.Read())
+                {
+                    switch (parser.CurrentEventType)
+                    {
+                        case ParseEventType.StreamStart:
+                        case ParseEventType.StreamEnd:
+                        case ParseEventType.DocumentStart:
+                        case ParseEventType.DocumentEnd:
+                            // Skip structural events
+                            break;
+                            
+                        case ParseEventType.Comment:
+                            var commentText = parser.GetScalarAsString() ?? "";
+                            events.Add($"COMMENT:{commentText.Trim()}");
+                            break;
+                            
+                        case ParseEventType.MappingStart:
+                            events.Add("MAPPING_START");
+                            break;
+                            
+                        case ParseEventType.MappingEnd:
+                            events.Add("MAPPING_END");
+                            break;
+                            
+                        case ParseEventType.SequenceStart:
+                            events.Add("SEQUENCE_START");
+                            break;
+                            
+                        case ParseEventType.SequenceEnd:
+                            events.Add("SEQUENCE_END");
+                            break;
+                            
+                        case ParseEventType.Scalar:
+                            var value = parser.GetScalarAsString() ?? "";
+                            events.Add($"SCALAR:{value}");
+                            break;
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                // If parsing fails, fall back to simple line-based comparison
+                // This should help us see what's different
+                return [$"PARSE_ERROR:{ex.Message}", yaml.Replace("\n", "\\n")];
+            }
+            
+            return events;
+        }
+    }
+}

--- a/VYaml.Tests/Parser/CommentHandlingTest.cs
+++ b/VYaml.Tests/Parser/CommentHandlingTest.cs
@@ -1,0 +1,536 @@
+using System.Buffers;
+using System.Text;
+using NUnit.Framework;
+using VYaml.Parser;
+
+namespace VYaml.Tests.Parser
+{
+    /// <summary>
+    /// Unit test class for validating YAML comment handling functionality in the parser.
+    /// This class contains multiple test cases that assess the parser's ability to process
+    /// and manage comments in various YAML structures and scenarios, ensuring robust and
+    /// accurate handling of comments according to specified options and behaviors.
+    /// </summary>
+    [TestFixture]
+    public class CommentHandlingTest
+    {
+        /// <summary>
+        /// Validates that when a YAML document starts with a comment and, the comment is preserved
+        /// properly by the parser when the appropriate parser options are configured.
+        /// </summary>
+        /// <remarks>
+        /// This test ensures that:
+        /// - Comments at the document start are correctly identified as a `Comment` event.
+        /// - The comment content is correctly retrieved using the parser.
+        /// - Events following the comment are correctly processed, such as mapping starts.
+        /// It uses a YAML parser configured with the `PreserveComments` and `StripLeadingWhitespace` options.
+        /// </remarks>
+        [Test]
+        public void CommentAtDocumentStart()
+        {
+            const string yaml = """
+                                # Document header comment
+                                key: value
+                                """;
+            var options = new YamlParserOptions { PreserveComments = true, StripLeadingWhitespace = false };
+            var parser = CreateParser(yaml, options);
+
+            // StreamStart
+            Assert.That(parser.Read(), Is.True);
+            Assert.That(parser.CurrentEventType, Is.EqualTo(ParseEventType.StreamStart));
+            
+            // DocumentStart
+            Assert.That(parser.Read(), Is.True);
+            Assert.That(parser.CurrentEventType, Is.EqualTo(ParseEventType.DocumentStart));
+            
+            // Comment
+            Assert.That(parser.Read(), Is.True);
+            Assert.That(parser.CurrentEventType, Is.EqualTo(ParseEventType.Comment));
+            Assert.That(parser.GetScalarAsString(), Is.EqualTo(" Document header comment"));
+            
+            // MappingStart
+            Assert.That(parser.Read(), Is.True);
+            Assert.That(parser.CurrentEventType, Is.EqualTo(ParseEventType.MappingStart));
+        }
+
+        /// <summary>
+        /// Tests the handling of YAML comments with leading spaces while parsing.
+        /// </summary>
+        /// <remarks>
+        /// The method verifies that a YAML comment with leading spaces is correctly identified and preserved
+        /// when parsing a YAML document. It uses custom parser options to retain comments and avoid stripping
+        /// leading whitespace.
+        /// </remarks>
+        /// <example>
+        /// It ensures that the comment is detected as a <see cref="ParseEventType.Comment"/> event,
+        /// and the content of the comment, including its leading spaces, can be retrieved as expected.
+        /// </example>
+        [Test]
+        public void CommentWithLeadingSpaces()
+        {
+            const string yaml = """
+                                key: value
+                                    # This comment has leading spaces
+                                next: value2
+                                """;
+            var options = new YamlParserOptions { PreserveComments = true, StripLeadingWhitespace = false };
+            var parser = CreateParser(yaml, options);
+            
+            parser.SkipHeader();
+            parser.Read(); // key
+            parser.Read(); // value
+            
+            // Comment with leading spaces
+            parser.Read();
+            Assert.That(parser.CurrentEventType, Is.EqualTo(ParseEventType.Comment));
+            Assert.That(parser.GetScalarAsString(), Is.EqualTo(" This comment has leading spaces"));
+        }
+
+        /// <summary>
+        /// Validates the parsing of YAML documents to ensure the correct handling of blank lines and comments.
+        /// </summary>
+        /// <remarks>
+        /// This method tests the following scenarios:
+        /// - YAML documents containing blank lines followed by a comment.
+        /// - Preservation of comments when the parser is configured to do so.
+        /// - Correct parsing of keys and values in the presence of comments and blank lines.
+        /// The method ensures:
+        /// - Comments appearing after blank lines are parsed correctly as a comment event.
+        /// - YAML scalars (keys and values) are parsed correctly despite the presence of blank lines and comments.
+        /// - Configuration options for comment preservation and white-space stripping function as expected.
+        /// </remarks>
+        [Test]
+        public void BlankLinesAndComments()
+        {
+            const string yaml = """
+                                key1: value1
+
+                                # Comment after blank line
+
+                                key2: value2
+                                """;
+            var options = new YamlParserOptions { PreserveComments = true, StripLeadingWhitespace = false };
+            var parser = CreateParser(yaml, options);
+            
+            parser.SkipHeader();
+            
+            // key1
+            parser.Read();
+            Assert.That(parser.GetScalarAsString(), Is.EqualTo("key1"));
+            
+            // value1
+            parser.Read();
+            Assert.That(parser.GetScalarAsString(), Is.EqualTo("value1"));
+            
+            // Comment
+            parser.Read();
+            Assert.That(parser.CurrentEventType, Is.EqualTo(ParseEventType.Comment));
+            Assert.That(parser.GetScalarAsString(), Is.EqualTo(" Comment after blank line"));
+            
+            // key2
+            parser.Read();
+            Assert.That(parser.GetScalarAsString(), Is.EqualTo("key2"));
+        }
+
+        /// <summary>
+        /// Validates that the YAML parser correctly handles and preserves comments
+        /// that are positioned between mapping entries when the parser is configured to do so.
+        /// This test ensures that comments within mappings are properly captured and
+        /// can be identified as distinct parse events of type <see cref="ParseEventType.Comment"/>.
+        /// </summary>
+        /// <remarks>
+        /// The test utilizes a YAML input containing two key-value pairs separated by a
+        /// comment. It confirms that the parser processes the key-value pairs and the
+        /// intermediate comment in sequence while adhering to the options specified in
+        /// <see cref="YamlParserOptions"/>.
+        /// </remarks>
+        /// <exception cref="AssertionException">
+        /// Thrown if the parser does not correctly identify the comment between entries or
+        /// if the parsing sequence does not match the expected behavior.
+        /// </exception>
+        [Test]
+        public void CommentBetweenMappingEntries()
+        {
+            const string yaml = """
+                                key1: value1
+                                # Comment between entries
+                                key2: value2
+                                """;
+            var options = new YamlParserOptions { PreserveComments = true, StripLeadingWhitespace = false };
+            var parser = CreateParser(yaml, options);
+            
+            parser.SkipHeader();
+            Assert.That(parser.CurrentEventType, Is.EqualTo(ParseEventType.MappingStart));
+            
+            // key1
+            parser.Read();
+            Assert.That(parser.CurrentEventType, Is.EqualTo(ParseEventType.Scalar));
+            Assert.That(parser.GetScalarAsString(), Is.EqualTo("key1"));
+            
+            // value1
+            parser.Read();
+            Assert.That(parser.CurrentEventType, Is.EqualTo(ParseEventType.Scalar));
+            Assert.That(parser.GetScalarAsString(), Is.EqualTo("value1"));
+            
+            // Comment
+            parser.Read();
+            Assert.That(parser.CurrentEventType, Is.EqualTo(ParseEventType.Comment));
+            Assert.That(parser.GetScalarAsString(), Is.EqualTo(" Comment between entries"));
+            
+            // key2
+            parser.Read();
+            Assert.That(parser.CurrentEventType, Is.EqualTo(ParseEventType.Scalar));
+            Assert.That(parser.GetScalarAsString(), Is.EqualTo("key2"));
+        }
+
+        /// <summary>
+        /// Tests the correct handling of inline comments that follow a scalar value in a YAML document.
+        /// The test verifies that the parser identifies and processes the inline comment
+        /// as a comment event after parsing the associated scalar key-value pair.
+        /// </summary>
+        [Test]
+        public void InlineCommentAfterScalar()
+        {
+            const string yaml = "key: value # inline comment";
+            var options = new YamlParserOptions { PreserveComments = true, StripLeadingWhitespace = false };
+            var parser = CreateParser(yaml, options);
+            
+            parser.SkipHeader();
+            Assert.That(parser.CurrentEventType, Is.EqualTo(ParseEventType.MappingStart));
+            
+            // key
+            parser.Read();
+            Assert.That(parser.CurrentEventType, Is.EqualTo(ParseEventType.Scalar));
+            
+            // value
+            parser.Read();
+            Assert.That(parser.CurrentEventType, Is.EqualTo(ParseEventType.Scalar));
+            
+            // Comment
+            parser.Read();
+            Assert.That(parser.CurrentEventType, Is.EqualTo(ParseEventType.Comment));
+            Assert.That(parser.GetScalarAsString(), Is.EqualTo(" inline comment"));
+        }
+
+        /// <summary>
+        /// Validates the behavior of parsing a YAML document containing a mid-line comment
+        /// preceded by spaces.
+        /// </summary>
+        /// <remarks>
+        /// This method examines how the parser handles comments that appear mid-line in a
+        /// YAML document when preceded by spaces. It ensures the comment is correctly
+        /// identified and preserved when the appropriate parsing options are enabled.
+        /// </remarks>
+        /// <seealso cref="YamlParser"/>
+        /// <seealso cref="YamlParserOptions"/>
+        /// <seealso cref="ParseEventType.Comment"/>
+        [Test]
+        public void MidLineCommentWithSpaces()
+        {
+            const string yaml = "key: value    # comment with spaces before it";
+            var options = new YamlParserOptions { PreserveComments = true, StripLeadingWhitespace = false };
+            var parser = CreateParser(yaml, options);
+            
+            parser.SkipHeader();
+            parser.Read(); // key
+            parser.Read(); // value
+            
+            // Comment
+            parser.Read();
+            Assert.That(parser.CurrentEventType, Is.EqualTo(ParseEventType.Comment));
+            Assert.That(parser.GetScalarAsString(), Is.EqualTo(" comment with spaces before it"));
+        }
+
+        /// <summary>
+        /// Verifies that comments appearing after a colon in a YAML mapping entry are correctly parsed and preserved when
+        /// the PreserveComments option is enabled in the parser.
+        /// </summary>
+        /// <remarks>
+        /// This method tests the parsing of YAML documents with comments immediately following colons within mapping
+        /// entries. It ensures that such comments are parsed into separate comment events, preserving their content
+        /// as expected, without interfering with the scalar values of keys and values.
+        /// </remarks>
+        /// <exception cref="AssertionException">
+        /// Thrown if any part of the parsed YAML document does not match the expected outcome, such as the absence
+        /// of expected comment events or mismatched scalar values.
+        /// </exception>
+        [Test]
+        public void CommentAfterColon()
+        {
+            const string yaml = """
+                                key: # comment after colon
+                                  value
+                                """;
+            var options = new YamlParserOptions { PreserveComments = true, StripLeadingWhitespace = false };
+            var parser = CreateParser(yaml, options);
+            
+            parser.SkipHeader();
+            
+            // key
+            parser.Read();
+            Assert.That(parser.CurrentEventType, Is.EqualTo(ParseEventType.Scalar));
+            Assert.That(parser.GetScalarAsString(), Is.EqualTo("key"));
+            
+            // Comment
+            parser.Read();
+            Assert.That(parser.CurrentEventType, Is.EqualTo(ParseEventType.Comment));
+            Assert.That(parser.GetScalarAsString(), Is.EqualTo(" comment after colon"));
+            
+            // value
+            parser.Read();
+            Assert.That(parser.CurrentEventType, Is.EqualTo(ParseEventType.Scalar));
+            Assert.That(parser.GetScalarAsString(), Is.EqualTo("value"));
+        }
+
+        /// <summary>
+        /// Tests the ability of the YAML parser to correctly handle comments within a sequence.
+        /// Verifies that the parser preserves comments when the appropriate option is enabled.
+        /// </summary>
+        /// <remarks>
+        /// The test validates multiple parsing stages, including mapping, sequence, scalar values, and comment handling.
+        /// Specific assertions are made to check that comments are recognized as distinct parse events
+        /// and their content is preserved as expected.
+        /// </remarks>
+        [Test]
+        public void CommentInSequence()
+        {
+            const string yaml = """
+                                items:
+                                  - item1
+                                  # Comment in sequence
+                                  - item2
+                                """;
+            var options = new YamlParserOptions { PreserveComments = true, StripLeadingWhitespace = false };
+            var parser = CreateParser(yaml, options);
+            
+            parser.SkipHeader();
+            
+            // MappingStart
+            Assert.That(parser.CurrentEventType, Is.EqualTo(ParseEventType.MappingStart));
+            
+            // key: items
+            parser.Read();
+            Assert.That(parser.CurrentEventType, Is.EqualTo(ParseEventType.Scalar));
+            Assert.That(parser.GetScalarAsString(), Is.EqualTo("items"));
+            
+            // SequenceStart
+            parser.Read();
+            Assert.That(parser.CurrentEventType, Is.EqualTo(ParseEventType.SequenceStart));
+            
+            // item1
+            parser.Read();
+            Assert.That(parser.CurrentEventType, Is.EqualTo(ParseEventType.Scalar));
+            Assert.That(parser.GetScalarAsString(), Is.EqualTo("item1"));
+            
+            // Comment
+            parser.Read();
+            Assert.That(parser.CurrentEventType, Is.EqualTo(ParseEventType.Comment));
+            Assert.That(parser.GetScalarAsString(), Is.EqualTo(" Comment in sequence"));
+            
+            // item2
+            parser.Read();
+            Assert.That(parser.CurrentEventType, Is.EqualTo(ParseEventType.Scalar));
+            Assert.That(parser.GetScalarAsString(), Is.EqualTo("item2"));
+        }
+
+        /// <summary>
+        /// Validates the parser's behavior with empty comment lines in a YAML document.
+        /// </summary>
+        /// <remarks>
+        /// The method specifically tests scenarios where a YAML document contains an empty
+        /// comment line (a line that only has a '#' with no additional content). It ensures
+        /// that the parser correctly identifies this as a comment and assigns it an empty string
+        /// as the associated scalar value.
+        /// </remarks>
+        /// <example>
+        /// This test uses a combination of YAML input and parsing settings to simulate and
+        /// verify the expected behavior of handling empty comments. It asserts that the
+        /// `ParseEventType` for the comment is correctly set to `ParseEventType.Comment`
+        /// and that the scalar value of the comment is an empty string.
+        /// </example>
+        [Test]
+        public void EmptyComment()
+        {
+            const string yaml = """
+                                key: value
+                                #
+                                next: value2
+                                """;
+            var options = new YamlParserOptions { PreserveComments = true, StripLeadingWhitespace = false };
+            var parser = CreateParser(yaml, options);
+            
+            parser.SkipHeader();
+            
+            // Skip to after first key-value pair
+            parser.Read(); // key
+            parser.Read(); // value
+            
+            // Empty comment
+            parser.Read();
+            Assert.That(parser.CurrentEventType, Is.EqualTo(ParseEventType.Comment));
+            Assert.That(parser.GetScalarAsString(), Is.EqualTo(""));
+        }
+
+        /// <summary>
+        /// Ensures that multiple consecutive comments in YAML documents are
+        /// correctly parsed and preserved according to the specified parser options.
+        /// </summary>
+        /// <remarks>
+        /// This method verifies the behavior of the parser when handling
+        /// multiple consecutive comments. It checks that each comment is
+        /// read sequentially with the expected event type and that the content
+        /// matches the expected comment text. Additionally, it ensures that
+        /// subsequent parsing of other YAML components, such as mappings,
+        /// continues correctly after processing the comments.
+        /// </remarks>
+        [Test]
+        public void MultipleConsecutiveComments()
+        {
+            const string yaml = """
+                                # First comment
+                                # Second comment
+                                # Third comment
+                                key: value
+                                """;
+            var options = new YamlParserOptions { PreserveComments = true, StripLeadingWhitespace = false };
+            var parser = CreateParser(yaml, options);
+            
+            // StreamStart
+            parser.Read();
+            Assert.That(parser.CurrentEventType, Is.EqualTo(ParseEventType.StreamStart));
+            
+            // DocumentStart
+            parser.Read();
+            Assert.That(parser.CurrentEventType, Is.EqualTo(ParseEventType.DocumentStart));
+            
+            // First comment
+            parser.Read();
+            Assert.That(parser.CurrentEventType, Is.EqualTo(ParseEventType.Comment));
+            Assert.That(parser.GetScalarAsString(), Is.EqualTo(" First comment"));
+            
+            // Second comment
+            parser.Read();
+            Assert.That(parser.CurrentEventType, Is.EqualTo(ParseEventType.Comment));
+            Assert.That(parser.GetScalarAsString(), Is.EqualTo(" Second comment"));
+            
+            // Third comment
+            parser.Read();
+            Assert.That(parser.CurrentEventType, Is.EqualTo(ParseEventType.Comment));
+            Assert.That(parser.GetScalarAsString(), Is.EqualTo(" Third comment"));
+            
+            // MappingStart
+            parser.Read();
+            Assert.That(parser.CurrentEventType, Is.EqualTo(ParseEventType.MappingStart));
+        }
+
+        /// <summary>
+        /// Tests parsing and handling of comments containing special characters in YAML.
+        /// </summary>
+        /// <remarks>
+        /// This method validates that comments with special characters such as "!@#$%^&*()"
+        /// are correctly identified and preserved when the corresponding parsing options
+        /// are enabled. It ensures that the parser can maintain comments accurately without
+        /// misinterpreting or discarding special characters.
+        /// </remarks>
+        [Test]
+        public void CommentWithSpecialCharacters()
+        {
+            const string yaml = "key: value # Comment with special chars: !@#$%^&*()";
+            var options = new YamlParserOptions { PreserveComments = true, StripLeadingWhitespace = false };
+            var parser = CreateParser(yaml, options);
+            
+            parser.SkipHeader();
+            parser.Read(); // key
+            parser.Read(); // value
+            
+            parser.Read();
+            Assert.That(parser.CurrentEventType, Is.EqualTo(ParseEventType.Comment));
+            Assert.That(parser.GetScalarAsString(), Is.EqualTo(" Comment with special chars: !@#$%^&*()"));
+        }
+
+        /// <summary>
+        /// Validates the parser's ability to correctly handle comments that resemble YAML content.
+        /// </summary>
+        /// <remarks>
+        /// This test verifies that comments which contain YAML-like syntax, such as `key: value`, are correctly recognized as comments
+        /// and not misconstrued as actual YAML mappings. The comments must be preserved when `PreserveComments` is enabled in parser options.
+        /// This ensures that the parser's comment handling logic remains robust and accurate.
+        /// </remarks>
+        /// <exception cref="AssertionException">
+        /// Thrown if the parser fails to identify the correct event type for the comment or does not preserve the comment content.
+        /// </exception>
+        [Test]
+        public void CommentWithYamlLikeContent()
+        {
+            const string yaml = """
+                                key: value
+                                # This looks like YAML: key: value but it's a comment
+                                next: value2
+                                """;
+            var options = new YamlParserOptions { PreserveComments = true, StripLeadingWhitespace = false };
+            var parser = CreateParser(yaml, options);
+            
+            parser.SkipHeader();
+            parser.Read(); // key
+            parser.Read(); // value
+            
+            parser.Read();
+            Assert.That(parser.CurrentEventType, Is.EqualTo(ParseEventType.Comment));
+            Assert.That(parser.GetScalarAsString(), Is.EqualTo(" This looks like YAML: key: value but it's a comment"));
+        }
+
+        /// <summary>
+        /// Test method to verify that comments are not preserved in the YAML parsing process
+        /// when the <see cref="YamlParserOptions.PreserveComments"/> option is disabled.
+        /// </summary>
+        /// <remarks>
+        /// This test processes a YAML input containing comments and checks that the parser
+        /// skips over all comment events and directly parses the mapping and scalar content.
+        /// </remarks>
+        /// <example>
+        /// Parses a YAML document where comments are included but ensures only the mapping
+        /// and scalar elements are processed when comment preservation is disabled.
+        /// </example>
+        [Test]
+        public void CommentsNotPreservedWhenDisabled()
+        {
+            const string yaml = """
+                                # Comment
+                                key: value # inline comment
+                                # Another comment
+                                key2: value2
+                                """;
+            var parser = CreateParser(yaml, YamlParserOptions.Default);
+            
+            parser.SkipHeader();
+            
+            // Should skip all comments and go straight to mapping content
+            Assert.That(parser.CurrentEventType, Is.EqualTo(ParseEventType.MappingStart));
+            
+            parser.Read();
+            Assert.That(parser.CurrentEventType, Is.EqualTo(ParseEventType.Scalar));
+            Assert.That(parser.GetScalarAsString(), Is.EqualTo("key"));
+            
+            parser.Read();
+            Assert.That(parser.CurrentEventType, Is.EqualTo(ParseEventType.Scalar));
+            Assert.That(parser.GetScalarAsString(), Is.EqualTo("value"));
+            
+            parser.Read();
+            Assert.That(parser.CurrentEventType, Is.EqualTo(ParseEventType.Scalar));
+            Assert.That(parser.GetScalarAsString(), Is.EqualTo("key2"));
+        }
+
+        /// <summary>
+        /// Creates and initializes an instance of the <see cref="YamlParser"/> with the provided YAML string and parser options.
+        /// </summary>
+        /// <param name="yaml">The string containing YAML content to be parsed.</param>
+        /// <param name="options">An instance of <see cref="YamlParserOptions"/> specifying parser behavior such as comment preservation and whitespace handling.</param>
+        /// <returns>A new instance of <see cref="YamlParser"/> configured with the specified options and ready to parse the provided YAML content.</returns>
+        private static YamlParser CreateParser(string yaml, YamlParserOptions options)
+        {
+            var bytes = Encoding.UTF8.GetBytes(yaml);
+            var sequence = new ReadOnlySequence<byte>(bytes);
+            return new YamlParser(sequence, options);
+        }
+    }
+}

--- a/VYaml.Tests/Parser/Utf8HandlingTest.cs
+++ b/VYaml.Tests/Parser/Utf8HandlingTest.cs
@@ -1,0 +1,225 @@
+using System.Collections.Generic;
+using System.Text;
+using NUnit.Framework;
+using VYaml.Parser;
+using VYaml.Serialization;
+
+namespace VYaml.Tests.Parser
+{
+    /// <summary>
+    /// Unit tests for validating UTF-8 character handling in YAML parsing mechanisms within the VYaml library.
+    /// Ensures correctness and robustness when processing full-width Unicode characters and other special cases.
+    /// </summary>
+    [TestFixture]
+    public class Utf8HandlingTest
+    {
+        /// <summary>
+        /// Verifies that the YAML parser does not lock up when parsing a scalar value containing a full-width Unicode number.
+        /// Ensures proper handling of full-width characters, such as "２" (U+FF12), within the YAML document.
+        /// </summary>
+        [Test]
+        public void Parse_FullWidthNumber_ShouldNotLockup()
+        {
+            // Full-width "２" (U+FF12)
+            const string yaml = "value: ２";
+            var bytes = Encoding.UTF8.GetBytes(yaml);
+            
+            var parser = YamlParser.FromBytes(bytes);
+            parser.SkipAfter(ParseEventType.MappingStart);
+            
+            Assert.That(parser.ReadScalarAsString(), Is.EqualTo("value"));
+            Assert.That(parser.ReadScalarAsString(), Is.EqualTo("２"));
+        }
+
+        /// <summary>
+        /// Validates that parsing YAML scalars containing full-width numeric characters
+        /// at the end of their value does not cause the parser to lock up.
+        /// Iterates through various Unicode full-width numbers.
+        /// </summary>
+        [Test]
+        public void Parse_FullWidthNumbersAtEndOfScalar_ShouldNotLockup()
+        {
+            // Test various full-width numbers at the end without trailing whitespace
+            var fullWidthNumbers = new[] { "０", "１", "２", "３", "４", "５", "６", "７", "８", "９" };
+            
+            foreach (var num in fullWidthNumbers)
+            {
+                var yaml = $"value: test{num}";
+                var bytes = Encoding.UTF8.GetBytes(yaml);
+                
+                var parser = YamlParser.FromBytes(bytes);
+                parser.SkipAfter(ParseEventType.MappingStart);
+                
+                Assert.That(parser.ReadScalarAsString(), Is.EqualTo("value"));
+                Assert.That(parser.ReadScalarAsString(), Is.EqualTo($"test{num}"));
+            }
+        }
+
+        /// <summary>
+        /// Tests the ability of the YAML parser to correctly handle and parse YAML documents
+        /// containing a mix of ASCII and full-width Unicode characters.
+        /// This test ensures that both ASCII and full-width characters are parsed without any
+        /// errors or unexpected behaviour, preserving the integrity and structure of the content.
+        /// Verifies if the parser can handle full-width characters in both keys
+        /// and values within a YAML mapping structure correctly.
+        /// </summary>
+        /// <remarks>
+        /// Ensures no regressions related to Unicode handling, particularly the mix of ASCII
+        /// and full-width characters in YAML. This test is critical to validate compatibility
+        /// with internationalized content.
+        /// </remarks>
+        [Test]
+        public void Parse_MixedAsciiAndFullWidth_ShouldWork()
+        {
+            const string yaml = """
+
+                                title: Test １２３
+                                description: Full-width ＡＢＣ
+                                number: ２
+                                """;
+            
+            var bytes = Encoding.UTF8.GetBytes(yaml);
+            var parser = YamlParser.FromBytes(bytes);
+            
+            parser.SkipAfter(ParseEventType.MappingStart);
+
+            Assert.That(parser.ReadScalarAsString(), Is.EqualTo("title"));
+            Assert.That(parser.ReadScalarAsString(), Is.EqualTo("Test １２３"));
+            
+            Assert.That(parser.ReadScalarAsString(), Is.EqualTo("description"));
+            Assert.That(parser.ReadScalarAsString(), Is.EqualTo("Full-width ＡＢＣ"));
+            
+            Assert.That(parser.ReadScalarAsString(), Is.EqualTo("number"));
+            Assert.That(parser.ReadScalarAsString(), Is.EqualTo("２"));
+        }
+
+        /// <summary>
+        /// Verifies that parsing YAML strings containing an ideographic space (U+3000) does not cause a lockup or infinite loop.
+        /// Ensures the ideographic space is treated as part of the scalar value and is parsed correctly.
+        /// This test is designed to handle specific edge cases in UTF-8 character processing,
+        /// particularly for non-standard whitespace characters.
+        /// </summary>
+        [Test]
+        public void Parse_IdeographicSpace_ShouldNotLockup()
+        {
+            // Test with ideographic space (U+3000) - verifies no infinite loop
+            const string yaml = "value: 　test"; // Note: ideographic space after regular space
+            var bytes = Encoding.UTF8.GetBytes(yaml);
+            
+            var parser = YamlParser.FromBytes(bytes);
+            parser.SkipAfter(ParseEventType.MappingStart);
+            
+            Assert.That(parser.ReadScalarAsString(), Is.EqualTo("value"));
+            // Ideographic space is part of the scalar value
+            Assert.That(parser.ReadScalarAsString(), Is.EqualTo("　test"));
+        }
+
+        /// <summary>
+        /// Validates the YAML parser's ability to correctly handle and parse full-width brackets
+        /// within a scalar. This test ensures that full-width Unicode characters
+        /// such as ［ and ］ are treated as part of the content and not as flow symbols.
+        /// </summary>
+        /// <remarks>
+        /// This test addresses the proper handling of full-width Unicode characters in YAML
+        /// parsing to prevent errors or incorrect parsing behavior.
+        /// </remarks>
+        [Test]
+        public void Parse_FullWidthBrackets_ShouldWork()
+        {
+            // Test full-width flow symbols
+            const string yaml = "array: ［item1， item2］";
+            var bytes = Encoding.UTF8.GetBytes(yaml);
+            
+            var parser = YamlParser.FromBytes(bytes);
+            parser.SkipAfter(ParseEventType.MappingStart);
+            
+            Assert.That(parser.ReadScalarAsString(), Is.EqualTo("array"));
+            // The parser should treat these as regular content, not flow symbols
+            Assert.That(parser.ReadScalarAsString(), Is.EqualTo("［item1， item2］"));
+        }
+
+        /// <summary>
+        /// Verifies the deserialization process of YAML content that includes full-width Unicode characters.
+        /// Ensures proper handling for full-width characters in the data, including names, numeric values, and other text.
+        /// </summary>
+        /// <remarks>
+        /// The test examines correct deserialization of YAML content that includes full-width alphanumeric characters
+        /// and ideographic text, ensuring compatibility with non-ASCII data. It extracts the data as key-value pairs
+        /// and validates the correctness of each value.
+        /// </remarks>
+        /// <exception cref="System.ArgumentNullException">Thrown if the YAML content is null or invalid for processing.</exception>
+        /// <exception cref="System.Collections.Generic.KeyNotFoundException">
+        /// Thrown if the required keys (e.g., "name", "age", "city") are not present in the deserialized dictionary.
+        /// </exception>
+        [Test]
+        public void Deserialize_FullWidthContent_ShouldWork()
+        {
+            const string yaml = """
+
+                                name: 田中太郎
+                                age: ２５
+                                city: 東京
+                                """;
+            
+            var data = YamlSerializer.Deserialize<Dictionary<string, string>>(Encoding.UTF8.GetBytes(yaml));
+            
+            Assert.Multiple(() =>
+            {
+                Assert.That(data["name"], Is.EqualTo("田中太郎"));
+                Assert.That(data["age"], Is.EqualTo("２５"));
+                Assert.That(data["city"], Is.EqualTo("東京"));
+            });
+        }
+
+        /// <summary>
+        /// Tests that parsing YAML containing a non-breaking space (U+00A0) does not result in a lockup.
+        /// This verifies correct handling of the non-breaking space character in the UTF-8 encoded input.
+        /// The parser should correctly process the document and include the non-breaking space as part of the scalar value.
+        /// </summary>
+        [Test]
+        public void Parse_NonBreakingSpace_ShouldNotLockup()
+        {
+            // Test with non-breaking space (U+00A0) - verifies no infinite loop
+            var yamlBytes = new byte[] { 
+                (byte)'v', (byte)'a', (byte)'l', (byte)'u', (byte)'e', (byte)':', (byte)' ',
+                0xC2, 0xA0, // UTF-8 encoding of NBSP
+                (byte)'t', (byte)'e', (byte)'s', (byte)'t' 
+            };
+            
+            var parser = YamlParser.FromBytes(yamlBytes);
+            parser.SkipAfter(ParseEventType.MappingStart);
+            
+            Assert.That(parser.ReadScalarAsString(), Is.EqualTo("value"));
+            // NBSP is part of the scalar value
+            Assert.That(parser.ReadScalarAsString(), Is.EqualTo("\u00A0test"));
+        }
+
+        /// <summary>
+        /// Tests that parsing an empty YAML document with a full-width Unicode character does not cause a lockup
+        /// in the YAML parser.
+        /// This test verifies the YAML parser's ability to handle edge cases where the document contains only
+        /// a single full-width Unicode character. It ensures that the parser can correctly handle and process
+        /// input without entering an infinite loop or throwing unexpected errors.
+        /// Specifically, the test:
+        /// - Encodes a string containing a single full-width Unicode character (`２`) as UTF-8 bytes.
+        /// - Initializes a `YamlParser` instance with the UTF-8 encoded bytes.
+        /// - Parses the document and validates that it reaches the expected scalar event type.
+        /// - Confirms that the scalar value matches the input string.
+        /// This scenario is critical for applications relying on parsing documents within the context of
+        /// multilingual and full-width character support in YAML data processing.
+        /// </summary>
+        [Test]
+        public void Parse_EmptyDocumentWithFullWidth_ShouldNotLockup()
+        {
+            // Edge case: only full-width character
+            const string yaml = "２";
+            var bytes = Encoding.UTF8.GetBytes(yaml);
+            
+            var parser = YamlParser.FromBytes(bytes);
+            parser.SkipAfter(ParseEventType.DocumentStart);
+            
+            Assert.That(parser.CurrentEventType, Is.EqualTo(ParseEventType.Scalar));
+            Assert.That(parser.ReadScalarAsString(), Is.EqualTo("２"));
+        }
+    }
+}

--- a/VYaml.Tests/Serialization/DateTimeFormatterTest.cs
+++ b/VYaml.Tests/Serialization/DateTimeFormatterTest.cs
@@ -17,7 +17,9 @@ namespace VYaml.Tests.Serialization
         public void Serialize_Local()
         {
             var result = Serialize(new DateTime(2022, 12, 31, 11, 22, 33, DateTimeKind.Local));
-            Assert.That(result.StartsWith("2022-12-31T11:22:33.0000000+"), Is.True);
+            // The timezone offset can be either positive (+) or negative (-)
+            Assert.That(result.StartsWith("2022-12-31T11:22:33.0000000+") || 
+                       result.StartsWith("2022-12-31T11:22:33.0000000-"), Is.True);
         }
 
         [Test]

--- a/VYaml.Tests/Serialization/GeneratedFormatterTest.cs
+++ b/VYaml.Tests/Serialization/GeneratedFormatterTest.cs
@@ -458,5 +458,126 @@ namespace VYaml.Tests.Serialization
                 new YamlSerializerOptions { NamingConvention = NamingConvention.UpperCamelCase });
             Assert.That(result2.B, Is.EqualTo(123));
         }
+
+        [Test]
+        public void Serialize_DefaultIgnoreCondition_Never()
+        {
+            var obj = new TypeWithNullableProperties
+            {
+                NullableString = null,
+                NonNullableString = "test",
+                NullableInt = null,
+                NonNullableInt = 0,
+                BoolValue = false,
+                DoubleValue = 0.0,
+                NullableObject = null,
+                NonNullableObject = new SimpleTypeOne { One = 42 }
+            };
+
+            var result = Serialize(obj, new YamlSerializerOptions 
+            { 
+                DefaultIgnoreCondition = YamlIgnoreCondition.Never 
+            });
+
+            Assert.That(result, Does.Contain("nullableString: null"));
+            Assert.That(result, Does.Contain("nonNullableString: test"));
+            Assert.That(result, Does.Contain("nullableInt: null"));
+            Assert.That(result, Does.Contain("nonNullableInt: 0"));
+            Assert.That(result, Does.Contain("boolValue: false"));
+            Assert.That(result, Does.Contain("doubleValue: 0"));
+            Assert.That(result, Does.Contain("nullableObject: null"));
+            Assert.That(result, Does.Contain("nonNullableObject:"));
+        }
+
+        [Test]
+        public void Serialize_DefaultIgnoreCondition_WhenWritingNull()
+        {
+            var obj = new TypeWithNullableProperties
+            {
+                NullableString = null,
+                NonNullableString = "test",
+                NullableInt = null,
+                NonNullableInt = 0,
+                BoolValue = false,
+                DoubleValue = 0.0,
+                NullableObject = null,
+                NonNullableObject = new SimpleTypeOne { One = 42 }
+            };
+
+            var result = Serialize(obj, new YamlSerializerOptions 
+            { 
+                DefaultIgnoreCondition = YamlIgnoreCondition.WhenWritingNull 
+            });
+
+            Assert.That(result, Does.Not.Contain("nullableString:"));
+            Assert.That(result, Does.Contain("nonNullableString: test"));
+            Assert.That(result, Does.Not.Contain("nullableInt:"));
+            Assert.That(result, Does.Contain("nonNullableInt: 0"));
+            Assert.That(result, Does.Contain("boolValue: false"));
+            Assert.That(result, Does.Contain("doubleValue: 0"));
+            Assert.That(result, Does.Not.Contain("nullableObject:"));
+            Assert.That(result, Does.Contain("nonNullableObject:"));
+        }
+
+        [Test]
+        public void Serialize_DefaultIgnoreCondition_WhenWritingDefault()
+        {
+            var obj = new TypeWithNullableProperties
+            {
+                NullableString = null,
+                NonNullableString = "test",
+                NullableInt = null,
+                NonNullableInt = 0,
+                BoolValue = false,
+                DoubleValue = 0.0,
+                NullableObject = null,
+                NonNullableObject = new SimpleTypeOne { One = 42 }
+            };
+
+            var result = Serialize(obj, new YamlSerializerOptions 
+            { 
+                DefaultIgnoreCondition = YamlIgnoreCondition.WhenWritingDefault 
+            });
+
+            Assert.That(result, Does.Not.Contain("nullableString:"));
+            Assert.That(result, Does.Contain("nonNullableString: test"));
+            Assert.That(result, Does.Not.Contain("nullableInt:"));
+            Assert.That(result, Does.Not.Contain("nonNullableInt:"));
+            Assert.That(result, Does.Not.Contain("boolValue:"));
+            Assert.That(result, Does.Not.Contain("doubleValue:"));
+            Assert.That(result, Does.Not.Contain("nullableObject:"));
+            Assert.That(result, Does.Contain("nonNullableObject:"));
+        }
+
+        [Test]
+        public void Serialize_DefaultIgnoreCondition_WithNonDefaultValues()
+        {
+            var obj = new TypeWithNullableProperties
+            {
+                NullableString = "not null",
+                NonNullableString = "test",
+                NullableInt = 42,
+                NonNullableInt = 100,
+                BoolValue = true,
+                DoubleValue = 3.14,
+                NullableObject = new SimpleTypeOne { One = 1 },
+                NonNullableObject = new SimpleTypeOne { One = 42 }
+            };
+
+            var result = Serialize(obj, new YamlSerializerOptions 
+            { 
+                DefaultIgnoreCondition = YamlIgnoreCondition.WhenWritingDefault 
+            });
+
+            // All properties should be present since none have default values
+            Assert.That(result, Does.Contain("nullableString: not null"));
+            Assert.That(result, Does.Contain("nonNullableString: test"));
+            Assert.That(result, Does.Contain("nullableInt: 42"));
+            Assert.That(result, Does.Contain("nonNullableInt: 100"));
+            Assert.That(result, Does.Contain("boolValue: true"));
+            Assert.That(result, Does.Contain("doubleValue: 3.14"));
+            Assert.That(result, Does.Contain("nullableObject:"));
+            Assert.That(result, Does.Contain("nonNullableObject:"));
+        }
     }
 }

--- a/VYaml.Tests/Serialization/NestedYamlFormatterTest.cs
+++ b/VYaml.Tests/Serialization/NestedYamlFormatterTest.cs
@@ -1,0 +1,307 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using VYaml.Annotations;
+using VYaml.Emitter;
+using VYaml.Parser;
+using VYaml.Serialization;
+
+namespace VYaml.Tests.Serialization
+{
+    /// <summary>
+    /// Test type representing a child object for nested deserialization tests.
+    /// </summary>
+    [YamlObject]
+    public partial class NestedTestChild
+    {
+        public string Id { get; set; } = "";
+    }
+
+    /// <summary>
+    /// Test type representing a parent object that references a child by ID.
+    /// </summary>
+    [YamlObject]
+    public partial class NestedTestParentWithChildId
+    {
+        public string Id { get; set; } = "";
+        public string ChildId { get; set; } = "";
+        public NestedTestChild? Child { get; set; }
+    }
+
+    /// <summary>
+    /// Test type representing a parent object with a collection of children.
+    /// </summary>
+    [YamlObject]
+    public partial class NestedTestParentWithChildren
+    {
+        public string Id { get; set; } = "";
+        public List<NestedTestChild> Children { get; set; } = new();
+    }
+
+    /// <summary>
+    /// Test type that tracks the number of nested deserialization calls.
+    /// </summary>
+    [YamlObject]
+    public partial class NestedTestCountingObject
+    {
+        public int Count { get; set; }
+        public int NestedCalls { get; set; }
+    }
+
+    /// <summary>
+    /// Test type containing a YAML string that gets deserialized.
+    /// </summary>
+    [YamlObject]
+    public partial class NestedTestDataWithYaml
+    {
+        public string Data { get; set; } = "";
+        public int ParsedValue { get; set; }
+    }
+
+    /// <summary>
+    /// Simple test type containing a single value.
+    /// </summary>
+    [YamlObject]
+    public partial class NestedTestSimpleValue
+    {
+        public int Value { get; set; }
+    }
+    /// <summary>
+    /// Tests for nested YAML deserialization within custom formatters.
+    /// Verifies that the fix for issue #149 works correctly.
+    /// </summary>
+    [TestFixture]
+    public class NestedYamlFormatterTest : FormatterTestBase
+    {
+        [Test]
+        public void Deserialize_YamlInsideFormatter_ShouldNotThrowInvalidOperationException()
+        {
+            // Arrange
+            var childrenYaml = @"
+- id: A
+- id: B
+- id: C";
+            var parentYaml = @"
+- id: Parent1
+  childId: A";
+
+            var resolver = new NestedYamlFormatterResolver(childrenYaml);
+            var options = new YamlSerializerOptions { Resolver = resolver };
+
+            var parents = Deserialize<List<NestedTestParentWithChildId>>(parentYaml, options);
+            
+            Assert.Multiple(() =>
+            {
+                Assert.That(parents, Is.Not.Null);
+                Assert.That(parents.Count, Is.EqualTo(1));
+                Assert.That(parents[0].Id, Is.EqualTo("Parent1"));
+                Assert.That(parents[0].Child, Is.Not.Null);
+                Assert.That(parents[0].Child!.Id, Is.EqualTo("A"));
+            });
+        }
+
+        [Test]
+        public void Deserialize_MultipleNestedYamlCalls_ShouldWorkCorrectly()
+        {
+            // This test verifies that multiple YAML deserializations can happen
+            // within a single formatter without corrupting the parser state
+            var resolver = new CountingFormatterResolver();
+            var options = new YamlSerializerOptions { Resolver = resolver };
+
+            var result = Deserialize<NestedTestCountingObject>("count: 3", options);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(result, Is.Not.Null);
+                Assert.That(result.Count, Is.EqualTo(3));
+                Assert.That(result.NestedCalls, Is.EqualTo(3));
+            });
+        }
+
+        [Test]
+        public void Deserialize_DeeplyNestedFormatters_ShouldHandleRecursion()
+        {
+            // This tests that the fix works even with deeply nested parsing
+            var resolver = new SimpleNestedFormatterResolver();
+            var options = new YamlSerializerOptions { Resolver = resolver };
+
+            var data = Deserialize<NestedTestDataWithYaml>("data: 'value: 42'", options);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(data, Is.Not.Null);
+                Assert.That(data.Data, Is.EqualTo("value: 42"));
+                Assert.That(data.ParsedValue, Is.EqualTo(42));
+            });
+        }
+
+        // Test types are defined at namespace level due to VYaml source generator requirements
+
+        // Custom resolvers and formatters
+        class CountingFormatterResolver : IYamlFormatterResolver
+        {
+            public IYamlFormatter<T>? GetFormatter<T>()
+            {
+                if (typeof(T) == typeof(NestedTestCountingObject))
+                    return (IYamlFormatter<T>?)new CountingFormatter();
+                return StandardResolver.Instance.GetFormatter<T>();
+            }
+        }
+
+        class CountingFormatter : IYamlFormatter<NestedTestCountingObject>
+        {
+            public void Serialize(ref Utf8YamlEmitter emitter, NestedTestCountingObject value, YamlSerializationContext context)
+            {
+                throw new NotImplementedException("Test only deserializes");
+            }
+
+            public NestedTestCountingObject Deserialize(ref YamlParser parser, YamlDeserializationContext context)
+            {
+                var obj = new NestedTestCountingObject();
+                
+                parser.ReadWithVerify(ParseEventType.MappingStart);
+                while (parser.CurrentEventType != ParseEventType.MappingEnd)
+                {
+                    var key = parser.ReadScalarAsString();
+                    switch (key)
+                    {
+                        case "count":
+                            obj.Count = parser.ReadScalarAsInt32();
+                            // Make nested deserialization calls
+                            for (int i = 0; i < obj.Count; i++)
+                            {
+                                var dummyYaml = "id: dummy" + i;
+                                var bytes = System.Text.Encoding.UTF8.GetBytes(dummyYaml);
+                                var dummy = YamlSerializer.Deserialize<NestedTestChild>(bytes);
+                                if (dummy != null)
+                                {
+                                    obj.NestedCalls++;
+                                }
+                            }
+                            break;
+                        default:
+                            parser.SkipCurrentNode();
+                            break;
+                    }
+                }
+                parser.ReadWithVerify(ParseEventType.MappingEnd);
+                
+                return obj;
+            }
+        }
+
+        class SimpleNestedFormatterResolver : IYamlFormatterResolver
+        {
+            public IYamlFormatter<T>? GetFormatter<T>()
+            {
+                if (typeof(T) == typeof(NestedTestDataWithYaml))
+                    return (IYamlFormatter<T>?)new DataWithYamlFormatter();
+                return StandardResolver.Instance.GetFormatter<T>();
+            }
+        }
+
+        class DataWithYamlFormatter : IYamlFormatter<NestedTestDataWithYaml>
+        {
+            public void Serialize(ref Utf8YamlEmitter emitter, NestedTestDataWithYaml value, YamlSerializationContext context)
+            {
+                throw new NotImplementedException("Test only deserializes");
+            }
+
+            public NestedTestDataWithYaml Deserialize(ref YamlParser parser, YamlDeserializationContext context)
+            {
+                var data = new NestedTestDataWithYaml();
+                
+                parser.ReadWithVerify(ParseEventType.MappingStart);
+                while (parser.CurrentEventType != ParseEventType.MappingEnd)
+                {
+                    var key = parser.ReadScalarAsString();
+                    switch (key)
+                    {
+                        case "data":
+                            data.Data = parser.ReadScalarAsString() ?? "";
+                            // Parse the YAML string to extract the value
+                            if (!string.IsNullOrEmpty(data.Data))
+                            {
+                                var yamlBytes = System.Text.Encoding.UTF8.GetBytes(data.Data);
+                                var parsed = YamlSerializer.Deserialize<NestedTestSimpleValue>(yamlBytes);
+                                data.ParsedValue = parsed?.Value ?? 0;
+                            }
+                            break;
+                        default:
+                            parser.SkipCurrentNode();
+                            break;
+                    }
+                }
+                parser.ReadWithVerify(ParseEventType.MappingEnd);
+                
+                return data;
+            }
+        }
+
+        class NestedYamlFormatterResolver : IYamlFormatterResolver
+        {
+            private readonly string childrenYaml;
+
+            public NestedYamlFormatterResolver(string childrenYaml)
+            {
+                this.childrenYaml = childrenYaml;
+            }
+
+            public IYamlFormatter<T>? GetFormatter<T>()
+            {
+                if (typeof(T) == typeof(NestedTestParentWithChildId))
+                    return (IYamlFormatter<T>?)new ParentWithChildIdFormatter(childrenYaml);
+                return StandardResolver.Instance.GetFormatter<T>();
+            }
+        }
+
+        class ParentWithChildIdFormatter : IYamlFormatter<NestedTestParentWithChildId>
+        {
+            private readonly string childrenYaml;
+
+            public ParentWithChildIdFormatter(string childrenYaml)
+            {
+                this.childrenYaml = childrenYaml;
+            }
+
+            public void Serialize(ref Utf8YamlEmitter emitter, NestedTestParentWithChildId value, YamlSerializationContext context)
+            {
+                throw new NotImplementedException("Test only deserializes");
+            }
+
+            public NestedTestParentWithChildId Deserialize(ref YamlParser parser, YamlDeserializationContext context)
+            {
+                var parent = new NestedTestParentWithChildId();
+                
+                parser.ReadWithVerify(ParseEventType.MappingStart);
+                while (parser.CurrentEventType != ParseEventType.MappingEnd)
+                {
+                    var key = parser.ReadScalarAsString();
+                    switch (key)
+                    {
+                        case "id":
+                            parent.Id = parser.ReadScalarAsString() ?? "";
+                            break;
+                        case "childId":
+                            var childId = parser.ReadScalarAsString() ?? "";
+                            parent.ChildId = childId;
+                            
+                            // This is where the nested YAML deserialization happens
+                            var childrenBytes = System.Text.Encoding.UTF8.GetBytes(childrenYaml);
+                            var children = YamlSerializer.Deserialize<List<NestedTestChild>>(childrenBytes);
+                            parent.Child = children.FirstOrDefault(c => c.Id == childId);
+                            break;
+                        default:
+                            parser.SkipCurrentNode();
+                            break;
+                    }
+                }
+                parser.ReadWithVerify(ParseEventType.MappingEnd);
+                
+                return parent;
+            }
+        }
+
+    }
+}

--- a/VYaml.Tests/Serialization/SerializerTest.cs
+++ b/VYaml.Tests/Serialization/SerializerTest.cs
@@ -1,12 +1,47 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 using NUnit.Framework;
+using VYaml.Annotations;
 using VYaml.Internal;
+using VYaml.Parser;
 using VYaml.Serialization;
 using VYaml.Tests.TypeDeclarations;
 
 namespace VYaml.Tests.Serialization
 {
+    /// <summary>
+    /// Represents a data structure used in YAML serialization and deserialization processes.
+    /// </summary>
+    /// <remarks>
+    /// This class is annotated with the YamlObject attribute to ensure compatibility with YAML serialization mechanisms.
+    /// It provides properties for testing the serialization and deserialization of simple objects with string and integer
+    /// data types.
+    /// </remarks>
+    [YamlObject]
+    internal partial class TestData
+    {
+        public string Name { get; init; } = "";
+        public int Value { get; init; }
+    }
+
+    /// <summary>
+    /// Represents a document for YAML serialization and deserialization testing.
+    /// </summary>
+    /// <remarks>
+    /// This class contains shared and reference data, used to validate YAML serialization
+    /// and deserialization processes in test scenarios. The class leverages the YamlObject
+    /// attribute to specify its compatibility with YAML operations and supports different
+    /// ways of preserving object references across multiple YAML documents.
+    /// </remarks>
+    [YamlObject]
+    internal partial class TestDocument
+    {
+        public TestData Shared { get; set; } = new();
+        public TestData Reference { get; set; } = new();
+    }
+
     [TestFixture]
     public class SerializerTest
     {
@@ -158,6 +193,223 @@ namespace VYaml.Tests.Serialization
             var empty = new ReadOnlyMemory<byte>(Array.Empty<byte>());
             var result1 = YamlSerializer.Deserialize<dynamic>(empty);
             Assert.That(result1, Is.Null);
+        }
+
+        /// <summary>
+        /// Deserializes multiple YAML documents and ensures that anchors defined in one document cannot be referenced by another.
+        /// Verifies that anchor definitions and their references are properly isolated within each respective document.
+        /// </summary>
+        /// <remarks>
+        /// The method processes a YAML input containing multiple documents where an anchor is defined in the first document
+        /// and an attempt is made to reference it in subsequent documents. The test confirms that such cross-document
+        /// references result in an error, as anchors are scoped to their containing document only.
+        /// </remarks>
+        /// <exception cref="YamlParserException">
+        /// Thrown when invalid cross-document references to anchors are detected, ensuring compliance with YAML's
+        /// document isolation rules regarding anchor scoping.
+        /// </exception>
+        [Test]
+        public void DeserializeMultipleDocuments_AnchorsDoNotLeakBetweenDocuments()
+        {
+            const string yaml = """
+                                ---
+                                shared: &shared_value
+                                  name: Document 1
+                                  value: 100
+                                reference: *shared_value
+                                ---
+                                # This should fail if anchors leak between documents
+                                reference: *shared_value
+                                """;
+
+            var yamlBytes = Encoding.UTF8.GetBytes(yaml);
+            
+            // The deserialization should fail because the second document tries to reference
+            // an anchor from the first document
+            Assert.Throws<YamlParserException>(() =>
+            {
+                _ = YamlSerializer.DeserializeMultipleDocuments<Dictionary<string, object>>(yamlBytes).ToList();
+            });
+        }
+
+        /// <summary>
+        /// Deserializes a YAML input containing multiple documents, where the same anchor name can be reused within separate documents.
+        /// Verifies that anchors are isolated to their respective documents and do not interfere with each other.
+        /// </summary>
+        /// <remarks>
+        /// Each document contains shared data using anchors and ensures that references within a single document point to the correct objects.
+        /// The test confirms that anchors with identical names in different documents do not share references and remain document-specific.
+        /// </remarks>
+        /// <returns>
+        /// A collection of deserialized objects, where each entry represents a single YAML document. Each document's anchor-based references
+        /// are validated for consistency and correctness within their isolated scopes.
+        /// </returns>
+        [Test]
+        public void DeserializeMultipleDocuments_SameAnchorNameCanBeReusedInDifferentDocuments()
+        {
+            const string yaml = """
+                                ---
+                                data: &anchor
+                                  document: 1
+                                  content: First document
+                                ref: *anchor
+                                ---
+                                data: &anchor
+                                  document: 2
+                                  content: Second document
+                                ref: *anchor
+                                ---
+                                data: &anchor
+                                  document: 3
+                                  content: Third document
+                                ref: *anchor
+                                """;
+
+            var yamlBytes = Encoding.UTF8.GetBytes(yaml);
+            var documents = YamlSerializer.DeserializeMultipleDocuments<Dictionary<string, object>>(yamlBytes).ToList();
+            
+            Assert.That(documents.Count, Is.EqualTo(3));
+            
+            for (var i = 0; i < 3; i++)
+            {
+                var doc = documents[i];
+                Assert.That(doc.ContainsKey("data"), Is.True);
+                Assert.That(doc.ContainsKey("ref"), Is.True);
+                
+                var data = doc["data"] as Dictionary<object, object>;
+                Assert.That(data, Is.Not.Null);
+                Assert.That(data!["document"], Is.EqualTo(i + 1));
+                Assert.That(data["content"], Is.EqualTo($"{i switch
+                {
+                    0 => "First",
+                    1 => "Second",
+                    _ => "Third"
+                }} document"));
+                
+                var reference = doc["ref"] as Dictionary<object, object>;
+                Assert.That(reference, Is.Not.Null);
+                Assert.That(ReferenceEquals(data, reference), Is.True);
+            }
+        }
+
+        /// <summary>
+        /// Deserializes a YAML input containing multiple documents into a collection of complex objects, verifying the use of YAML anchors
+        /// and references within individual documents.
+        /// </summary>
+        /// <returns>
+        /// A collection of deserialized objects where each item represents a single YAML document. Anchors within each document
+        /// are properly resolved, while anchors with the same name in different documents remain isolated.
+        /// </returns>
+        [Test]
+        public void DeserializeMultipleDocuments_ComplexObjectsWithAnchors()
+        {
+            const string yaml = """
+                                ---
+                                defaults: &defaults
+                                  host: localhost
+                                  port: 8080
+                                  timeout: 30
+                                servers:
+                                  - <<: *defaults
+                                    name: Server A
+                                  - <<: *defaults
+                                    name: Server B
+                                    port: 8081
+                                ---
+                                # New document - cannot reference previous anchors
+                                servers:
+                                  - name: Server C
+                                    host: example.com
+                                    port: 443
+                                """;
+
+            var yamlBytes = Encoding.UTF8.GetBytes(yaml);
+            var documents = YamlSerializer.DeserializeMultipleDocuments<Dictionary<string, object>>(yamlBytes).ToList();
+            
+            Assert.That(documents.Count, Is.EqualTo(2));
+            
+            // First document
+            var doc1 = documents[0];
+            Assert.That(doc1.ContainsKey("defaults"), Is.True);
+            Assert.That(doc1.ContainsKey("servers"), Is.True);
+            
+            var servers1 = doc1["servers"] as List<object>;
+            Assert.That(servers1, Is.Not.Null);
+            Assert.That(servers1!.Count, Is.EqualTo(2));
+            
+            var serverA = servers1[0] as Dictionary<object, object>;
+            Assert.That(serverA!["name"], Is.EqualTo("Server A"));
+            // Just verify the structure exists
+            Assert.That(serverA.ContainsKey("<<"), Is.True);
+            
+            var serverB = servers1[1] as Dictionary<object, object>;
+            Assert.That(serverB!["name"], Is.EqualTo("Server B"));
+            Assert.That(serverB["port"], Is.EqualTo(8081)); // Override
+            Assert.That(serverB.ContainsKey("<<"), Is.True);
+            
+            // Second document
+            var doc2 = documents[1];
+            Assert.That(doc2.ContainsKey("servers"), Is.True);
+            
+            var servers2 = doc2["servers"] as List<object>;
+            Assert.That(servers2, Is.Not.Null);
+            Assert.That(servers2!.Count, Is.EqualTo(1));
+            
+            var serverC = servers2[0] as Dictionary<object, object>;
+            Assert.That(serverC["name"], Is.EqualTo("Server C"));
+            Assert.That(serverC["host"], Is.EqualTo("example.com"));
+            Assert.That(serverC["port"], Is.EqualTo(443));
+        }
+
+        /// <summary>
+        /// Deserializes a YAML input containing multiple documents into a strongly-typed list of objects of the specified type.
+        /// </summary>
+        /// <remarks>
+        /// This method processes multiple YAML documents concatenated in a single input while maintaining their individual
+        /// document boundaries. It ensures shared anchors and references within each document are handled correctly and ensures
+        /// those bindings do not leak between separate documents. Anchors with the same name in different documents
+        /// are treated independently. Each document is deserialized into an object of the specified type.
+        /// </remarks>
+        /// <returns>
+        /// An enumerable collection of deserialized objects where each item corresponds to a single YAML document
+        /// in the input.
+        /// </returns>
+        [Test]
+        public void DeserializeMultipleDocuments_StronglyTypedObjects()
+        {
+            const string yaml = """
+                                ---
+                                shared: &data
+                                  name: Test Item
+                                  value: 42
+                                reference: *data
+                                ---
+                                shared:
+                                  name: Another Item
+                                  value: 99
+                                reference:
+                                  name: Different Reference
+                                  value: 123
+                                """;
+
+            var yamlBytes = Encoding.UTF8.GetBytes(yaml);
+            var documents = YamlSerializer.DeserializeMultipleDocuments<TestDocument>(yamlBytes).ToList();
+            
+            Assert.That(documents.Count, Is.EqualTo(2));
+            
+            // First document - shared and reference should be the same object
+            var doc1 = documents[0];
+            Assert.That(doc1.Shared.Name, Is.EqualTo("Test Item"));
+            Assert.That(doc1.Shared.Value, Is.EqualTo(42));
+            Assert.That(ReferenceEquals(doc1.Shared, doc1.Reference), Is.True);
+            
+            // Second document - shared and reference are different objects
+            var doc2 = documents[1];
+            Assert.That(doc2.Shared.Name, Is.EqualTo("Another Item"));
+            Assert.That(doc2.Shared.Value, Is.EqualTo(99));
+            Assert.That(doc2.Reference.Name, Is.EqualTo("Different Reference"));
+            Assert.That(doc2.Reference.Value, Is.EqualTo(123));
+            Assert.That(ReferenceEquals(doc2.Shared, doc2.Reference), Is.False);
         }
     }
 }

--- a/VYaml.Tests/TypeDeclarations/IgnoreCondition.cs
+++ b/VYaml.Tests/TypeDeclarations/IgnoreCondition.cs
@@ -1,0 +1,17 @@
+using VYaml.Annotations;
+
+namespace VYaml.Tests.TypeDeclarations
+{
+    [YamlObject]
+    public partial class TypeWithNullableProperties
+    {
+        public string? NullableString { get; set; }
+        public string NonNullableString { get; set; } = "default";
+        public int? NullableInt { get; set; }
+        public int NonNullableInt { get; set; }
+        public bool BoolValue { get; set; }
+        public double DoubleValue { get; set; }
+        public SimpleTypeOne? NullableObject { get; set; }
+        public SimpleTypeOne NonNullableObject { get; set; } = new SimpleTypeOne();
+    }
+}

--- a/VYaml/Emitter/YamlEmitOptions.cs
+++ b/VYaml/Emitter/YamlEmitOptions.cs
@@ -28,6 +28,21 @@ namespace VYaml.Emitter
         public static readonly YamlEmitOptions Default = new();
 
         public int IndentWidth { get; set; } = 2;
+        
+        /// <summary>
+        /// Gets or sets whether to preserve comments when emitting YAML.
+        /// When enabled, the emitter will write Comment events.
+        /// Default is false for backward compatibility.
+        /// </summary>
+        public bool PreserveComments { get; set; } = false;
+        
+        /// <summary>
+        /// Gets or sets whether to add a leading space after the # character in comments.
+        /// When enabled, a space is automatically added after # for non-empty comments.
+        /// This provides standard YAML formatting while allowing precise control when disabled.
+        /// Default is true for user convenience and standard formatting.
+        /// </summary>
+        public bool AddLeadingSpace { get; set; } = true;
 
         private ScalarStyle stringQuoteStyle = ScalarStyle.DoubleQuoted;
 

--- a/VYaml/Internal/EmitStringAnalyzer.cs
+++ b/VYaml/Internal/EmitStringAnalyzer.cs
@@ -87,6 +87,7 @@ namespace VYaml.Internal
                     case '`':
                     case '"':
                     case '\'':
+                    case '\t':
                         needsQuotes = true;
                         break;
                     case '\n':

--- a/VYaml/Parser/TokenType.cs
+++ b/VYaml/Parser/TokenType.cs
@@ -30,5 +30,6 @@ namespace VYaml.Parser
         DoubleQuotedScaler,
         LiteralScalar,
         FoldedScalar,
+        Comment,
     }
 }

--- a/VYaml/Parser/Utf8YamlTokenizer.cs
+++ b/VYaml/Parser/Utf8YamlTokenizer.cs
@@ -1436,7 +1436,7 @@ namespace VYaml.Parser
                     {
                         if (isLeadingBlanks && mark.Col < currentIndent && currentCode == YamlCodes.Tab)
                         {
-                            throw new YamlTokenizerException(mark, "While scanning a plain scaler, found a tab");
+                            throw new YamlTokenizerException(mark, "While scanning a plain scalar, found a tab");
                         }
                         if (!isLeadingBlanks)
                         {

--- a/VYaml/Parser/YamlParser.cs
+++ b/VYaml/Parser/YamlParser.cs
@@ -120,11 +120,22 @@ namespace VYaml.Parser
             CurrentEventType = default;
             lastAnchorId = -1;
 
-            anchors = anchorsBufferStatic ??= new Dictionary<string, int>();
-            anchors.Clear();
+            // Check if the static buffers are in use (nested parsing scenario)
+            if (stateStackBufferStatic != null && stateStackBufferStatic.Length > 0)
+            {
+                // Create new instances for nested parsing
+                anchors = new Dictionary<string, int>();
+                stateStack = new ExpandBuffer<ParseState>(16);
+            }
+            else
+            {
+                // Reuse static buffers for performance
+                anchors = anchorsBufferStatic ??= new Dictionary<string, int>();
+                anchors.Clear();
 
-            stateStack = stateStackBufferStatic ??= new ExpandBuffer<ParseState>(16);
-            stateStack.Clear();
+                stateStack = stateStackBufferStatic ??= new ExpandBuffer<ParseState>(16);
+                stateStack.Clear();
+            }
 
             currentScalar = null;
             currentTag = null;

--- a/VYaml/Parser/YamlParser.cs
+++ b/VYaml/Parser/YamlParser.cs
@@ -454,6 +454,10 @@ namespace VYaml.Parser
                 tokenizer.Read();
             }
 
+            // Clear anchors at document boundary per YAML 1.2 spec section 3.2.2.2
+            anchors.Clear();
+            lastAnchorId = 0;
+
             // TODO tag handling
             currentState = ParseState.DocumentStart;
             CurrentEventType = ParseEventType.DocumentEnd;

--- a/VYaml/Parser/YamlParserOptions.cs
+++ b/VYaml/Parser/YamlParserOptions.cs
@@ -1,0 +1,25 @@
+namespace VYaml.Parser
+{
+    /// <summary>
+    /// Options for controlling YAML parsing behavior.
+    /// </summary>
+    public class YamlParserOptions
+    {
+        public static readonly YamlParserOptions Default = new();
+
+        /// <summary>
+        /// Gets or sets whether to preserve comments during parsing.
+        /// When enabled, the parser will emit Comment events for comments in the YAML document.
+        /// Default is false for backward compatibility and performance.
+        /// </summary>
+        public bool PreserveComments { get; set; } = false;
+        
+        /// <summary>
+        /// Gets or sets whether to strip leading whitespace from comment content.
+        /// When enabled, leading whitespace after the # character is removed from comment text.
+        /// This provides user-friendly comment content while allowing round-trip fidelity when disabled.
+        /// Default is true for user convenience.
+        /// </summary>
+        public bool StripLeadingWhitespace { get; set; } = true;
+    }
+}

--- a/VYaml/Serialization/YamlIgnoreCondition.cs
+++ b/VYaml/Serialization/YamlIgnoreCondition.cs
@@ -1,0 +1,25 @@
+namespace VYaml.Serialization
+{
+    /// <summary>
+    /// Specifies the condition under which properties are ignored during serialization.
+    /// </summary>
+    public enum YamlIgnoreCondition
+    {
+        /// <summary>
+        /// Property is never ignored during serialization.
+        /// </summary>
+        Never = 0,
+
+        /// <summary>
+        /// Property is ignored when its value is null.
+        /// </summary>
+        WhenWritingNull = 1,
+
+        /// <summary>
+        /// Property is ignored when its value is the default for its type.
+        /// For reference types and nullable value types, the default is null.
+        /// For non-nullable value types, the default is the natural default (0 for numeric types, false for bool, etc.).
+        /// </summary>
+        WhenWritingDefault = 2,
+    }
+}

--- a/VYaml/Serialization/YamlSerializerOptions.cs
+++ b/VYaml/Serialization/YamlSerializerOptions.cs
@@ -3,6 +3,9 @@ using VYaml.Emitter;
 
 namespace VYaml.Serialization
 {
+    /// <summary>
+    /// Options for controlling YAML serialization behavior.
+    /// </summary>
     public class YamlSerializerOptions
     {
         public const NamingConvention DefaultNamingConvention = NamingConvention.LowerCamelCase;
@@ -15,5 +18,10 @@ namespace VYaml.Serialization
         public IYamlFormatterResolver Resolver { get; set; } = StandardResolver.Instance;
         public NamingConvention NamingConvention { get; set; } = DefaultNamingConvention;
         public YamlEmitOptions EmitOptions { get; set; } = new();
+        
+        /// <summary>
+        /// Gets or sets the default ignore condition for properties during serialization.
+        /// </summary>
+        public YamlIgnoreCondition DefaultIgnoreCondition { get; set; } = YamlIgnoreCondition.Never;
     }
 }


### PR DESCRIPTION
Fix multiple parser issues and implement DefaultIgnoreCondition feature and Comment Parsing Feature.

  Fixes:
  - Fix hadashiA/VYaml#155: Correct spelling of "attribute" (was "attribtue") in SymbolExtensions.cs
  - Fix hadashiA/VYaml#149: Support nested YAML deserialization by checking ThreadStatic buffer usage before reusing
  - Fix hadashiA/VYaml#133: Fix parser lockup with full-width Unicode characters by implementing proper UTF-8 support
  - Fix anchor scope isolation in multi-document YAML parsing

  Feature Implementation:
  - Implement hadashiA/VYaml#127: Add DefaultIgnoreCondition option to skip null/default values during serialization
   - Added YamlIgnoreCondition enum with Never, WhenWritingNull, and WhenWritingDefault options
   - Modified source generator to conditionally emit properties based on ignore condition
   - Support for hadashiA/VYaml#123 allowing comments to be emitted or ignored, and to allow for round trip processing

  Additional Changes:
  - Fix DateTimeFormatterTest to handle both positive and negative timezone offsets
  - Update System.Text.Json from 8.0.4 to 9.0.6 due to CVE security vulnerability (GHSA-8g4q-xg66-9fp4)
  - Add documentation for DefaultIgnoreCondition feature in README.md