### PR TITLE
Add YamlUnionMemberAttribute for "Union from derived or implementation class" approach

### DIFF
--- a/README.md
+++ b/README.md
@@ -493,6 +493,63 @@ Result:
 a: 100
 ```
 
+#### Polymorphism (Union from derived or implementation class)
+
+You can also define union relationships from the derived or implementation class side using `[YamlUnionMember]`.
+This approach is practical when you want to add new implementations without modifying the base type.
+
+``` csharp
+[YamlObject]
+public partial interface IUnionSample2
+{
+}
+
+[YamlObject]
+[YamlUnionMember("!baz", typeof(IUnionSample2))]
+public partial class BazClass : IUnionSample2
+{
+    public int A { get; set; }
+}
+```
+
+This works the same as `YamlObjectUnion` attribute:
+
+``` csharp
+// We can deserialize as interface type.
+var obj = YamlSerializer.Deserialize<IUnionSample2>(UTF8.GetBytes("!baz { a: 100 }"));
+
+Assert.That(obj, Is.TypeOf<BazClass>());
+```
+
+You can also serialize:
+
+``` csharp
+YamlSerializer.Serialize<IUnionSample2>(new Baz { A = 100 });
+```
+
+Result:
+``` yaml
+!baz
+a: 100
+```
+
+Both approaches can be mixed within the same union type:
+
+``` csharp
+[YamlObject]
+[YamlObjectUnion("!qux", typeof(QuxClass))]
+public partial interface IMixedUnion
+{
+}
+
+[YamlObject]
+public partial class QuxClass : IMixedUnion { }
+
+[YamlObject]
+[YamlUnionMember("!quux", typeof(IMixedUnion))]
+public partial class QuuxClass : IMixedUnion { }
+```
+
 ## Customize serialization behaviour
 
 - `IYamlFormatter<T>` is an interface customize the serialization behaviour of a your particular type.

--- a/VYaml.Annotations/Attributes.cs
+++ b/VYaml.Annotations/Attributes.cs
@@ -64,6 +64,22 @@ namespace VYaml.Annotations
     }
 
     /// <summary>
+    /// Marks a concrete type as a member of a union type, specifying the tag and parent union type
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct, AllowMultiple = false, Inherited = false)]
+    public sealed class YamlUnionMemberAttribute : Attribute
+    {
+        public string Tag { get; }
+        public Type UnionType { get; }
+
+        public YamlUnionMemberAttribute(string tag, Type unionType)
+        {
+            Tag = tag;
+            UnionType = unionType;
+        }
+    }
+
+    /// <summary>
     /// Preserve for Unity IL2CPP(internal but used for code generator)
     /// </summary>
     /// <remarks>

--- a/VYaml.SourceGenerator.Roslyn3/SyntaxContextReceiver.cs
+++ b/VYaml.SourceGenerator.Roslyn3/SyntaxContextReceiver.cs
@@ -6,10 +6,16 @@ namespace VYaml.SourceGenerator;
 class SyntaxContextReceiver : ISyntaxContextReceiver
 {
     readonly HashSet<TypeDeclarationSyntax> classDeclarations = new();
+    readonly HashSet<TypeDeclarationSyntax> unionMemberDeclarations = new();
 
     public IReadOnlyList<WorkItem> GetWorkItems()
     {
         return classDeclarations.Select(x => new WorkItem(x)).ToArray();
+    }
+
+    public IReadOnlyList<TypeDeclarationSyntax> GetUnionMemberDeclarations()
+    {
+        return unionMemberDeclarations.ToArray();
     }
 
     public void OnVisitSyntaxNode(GeneratorSyntaxContext context)
@@ -23,16 +29,19 @@ class SyntaxContextReceiver : ISyntaxContextReceiver
             var typeSyntax = (TypeDeclarationSyntax)node;
             if (typeSyntax.AttributeLists.Count > 0)
             {
-                var attr = typeSyntax.AttributeLists
-                    .SelectMany(x => x.Attributes)
-                    .FirstOrDefault(x => x.Name.ToString() is
-                        "YamlObject" or
-                        "YamlObjectAttribute" or
-                        "VYaml.Annotations.YamlObject" or
-                        "VYaml.Annotations.YamlObjectAttribute");
-                if (attr != null)
+                foreach (var attr in typeSyntax.AttributeLists.SelectMany(x => x.Attributes))
                 {
-                    classDeclarations.Add(typeSyntax);
+                    var name = attr.Name.ToString();
+                    if (name is "YamlObject" or "YamlObjectAttribute" or
+                        "VYaml.Annotations.YamlObject" or "VYaml.Annotations.YamlObjectAttribute")
+                    {
+                        classDeclarations.Add(typeSyntax);
+                    }
+                    else if (name is "YamlUnionMember" or "YamlUnionMemberAttribute" or
+                        "VYaml.Annotations.YamlUnionMember" or "VYaml.Annotations.YamlUnionMemberAttribute")
+                    {
+                        unionMemberDeclarations.Add(typeSyntax);
+                    }
                 }
             }
         } }

--- a/VYaml.SourceGenerator.Roslyn3/VYamlSourceGenerator.cs
+++ b/VYaml.SourceGenerator.Roslyn3/VYamlSourceGenerator.cs
@@ -20,6 +20,34 @@ public class VYamlSourceGenerator : ISourceGenerator
             var codeWriter = new CodeWriter();
             if (context.SyntaxContextReceiver! is not SyntaxContextReceiver syntaxCollector) return;
 
+            // Collect union member information
+            var unionMembersByType = new Dictionary<INamedTypeSymbol, List<(string Tag, INamedTypeSymbol SubType)>>(SymbolEqualityComparer.Default);
+            foreach (var unionMemberSyntax in syntaxCollector.GetUnionMemberDeclarations())
+            {
+                var semanticModel = context.Compilation.GetSemanticModel(unionMemberSyntax.SyntaxTree);
+                var symbol = semanticModel.GetDeclaredSymbol(unionMemberSyntax, context.CancellationToken);
+                if (symbol is INamedTypeSymbol typeSymbol)
+                {
+                    var attrs = symbol.GetAttributes().Where(x => 
+                        SymbolEqualityComparer.Default.Equals(x.AttributeClass, references.YamlUnionMemberAttribute));
+                    foreach (var attr in attrs)
+                    {
+                        if (attr.ConstructorArguments.Length == 2)
+                        {
+                            var tag = (string)attr.ConstructorArguments[0].Value!;
+                            var unionType = (INamedTypeSymbol)attr.ConstructorArguments[1].Value!;
+                            
+                            if (!unionMembersByType.TryGetValue(unionType, out var list))
+                            {
+                                list = new List<(string, INamedTypeSymbol)>();
+                                unionMembersByType[unionType] = list;
+                            }
+                            list.Add((tag, typeSymbol));
+                        }
+                    }
+                }
+            }
+
             foreach (var workItem in syntaxCollector.GetWorkItems())
             {
                 if (context.CancellationToken.IsCancellationRequested)
@@ -27,17 +55,29 @@ public class VYamlSourceGenerator : ISourceGenerator
                     return;
                 }
 
-                var typeMeta = workItem.Analyze(in context, references);
-                if (typeMeta is null) continue;
-
-                if (TryEmit(typeMeta, codeWriter, references, in context))
+                var semanticModel = context.Compilation.GetSemanticModel(workItem.Syntax.SyntaxTree);
+                var symbol = semanticModel.GetDeclaredSymbol(workItem.Syntax, context.CancellationToken);
+                if (symbol is INamedTypeSymbol typeSymbol)
                 {
-                    var fullType = typeMeta.FullTypeName
-                        .Replace("global::", "")
-                        .Replace("<", "_")
-                        .Replace(">", "_");
+                    var attributeData = symbol.GetAttributes().FirstOrDefault(x =>
+                    {
+                        var attribute = references.YamlObjectAttribute;
+                        return SymbolEqualityComparer.Default.Equals(x.AttributeClass, attribute);
+                    });
+                    if (attributeData is not null)
+                    {
+                        var typeMeta = new TypeMeta(workItem.Syntax, typeSymbol, attributeData, references, unionMembersByType);
 
-                    context.AddSource($"{fullType}.YamlFormatter.g.cs", codeWriter.ToString());
+                        if (TryEmit(typeMeta, codeWriter, references, in context))
+                        {
+                            var fullType = typeMeta.FullTypeName
+                                .Replace("global::", "")
+                                .Replace("<", "_")
+                                .Replace(">", "_");
+
+                            context.AddSource($"{fullType}.YamlFormatter.g.cs", codeWriter.ToString());
+                        }
+                    }
                 }
                 codeWriter.Clear();
             }

--- a/VYaml.SourceGenerator.Roslyn3/WorkItem.cs
+++ b/VYaml.SourceGenerator.Roslyn3/WorkItem.cs
@@ -27,7 +27,7 @@ class WorkItem
             {
                 return null;
             }
-            return new TypeMeta(Syntax, typeSymbol, attributeData, references);
+            return new TypeMeta(Syntax, typeSymbol, attributeData, references, null);
         }
         return null;
     }

--- a/VYaml.SourceGenerator/ReferenceSymbols.cs
+++ b/VYaml.SourceGenerator/ReferenceSymbols.cs
@@ -17,6 +17,7 @@ public class ReferenceSymbols
             YamlIgnoreAttribute = compilation.GetTypeByMetadataName("VYaml.Annotations.YamlIgnoreAttribute")!,
             YamlConstructorAttribute = compilation.GetTypeByMetadataName("VYaml.Annotations.YamlConstructorAttribute")!,
             YamlObjectUnionAttribute = compilation.GetTypeByMetadataName("VYaml.Annotations.YamlObjectUnionAttribute")!,
+            YamlUnionMemberAttribute = compilation.GetTypeByMetadataName("VYaml.Annotations.YamlUnionMemberAttribute")!,
             NamingConventionEnum = compilation.GetTypeByMetadataName("VYaml.Annotations.NamingConvention")!
         };
     }
@@ -26,5 +27,6 @@ public class ReferenceSymbols
     public INamedTypeSymbol YamlIgnoreAttribute { get; private set; } = default!;
     public INamedTypeSymbol YamlConstructorAttribute { get; private set; } = default!;
     public INamedTypeSymbol YamlObjectUnionAttribute { get; private set; } = default!;
+    public INamedTypeSymbol YamlUnionMemberAttribute { get; private set; } = default!;
     public INamedTypeSymbol NamingConventionEnum { get; private set; } = default!;
 }

--- a/VYaml.SourceGenerator/TypeMeta.cs
+++ b/VYaml.SourceGenerator/TypeMeta.cs
@@ -49,7 +49,8 @@ class TypeMeta
         TypeDeclarationSyntax syntax,
         INamedTypeSymbol symbol,
         AttributeData yamlObjectAttribute,
-        ReferenceSymbols references)
+        ReferenceSymbols references,
+        Dictionary<INamedTypeSymbol, List<(string Tag, INamedTypeSymbol SubType)>>? unionMembersByType = null)
     {
         Syntax = syntax;
         Symbol = symbol;
@@ -73,13 +74,24 @@ class TypeMeta
             .Where(x => !x.IsImplicitlyDeclared) // remove empty ctor(struct always generate it), record's clone ctor
             .ToArray();
 
-        UnionMetas = symbol.GetAttributes()
+        // Collect union metas from both YamlObjectUnionAttribute and YamlUnionMemberAttribute
+        var unionMetasList = new List<UnionMeta>();
+        
+        // From YamlObjectUnionAttribute (traditional approach)
+        unionMetasList.AddRange(symbol.GetAttributes()
             .Where(x => SymbolEqualityComparer.Default.Equals(x.AttributeClass, references.YamlObjectUnionAttribute))
             .Where(x => x.ConstructorArguments.Length == 2)
             .Select(x => new UnionMeta(
                 (string)x.ConstructorArguments[0].Value!,
-                (INamedTypeSymbol)x.ConstructorArguments[1].Value!))
-            .ToArray();
+                (INamedTypeSymbol)x.ConstructorArguments[1].Value!)));
+        
+        // From YamlUnionMemberAttribute (new approach)
+        if (unionMembersByType != null && unionMembersByType.TryGetValue(symbol, out var memberList))
+        {
+            unionMetasList.AddRange(memberList.Select(x => new UnionMeta(x.Tag, x.SubType)));
+        }
+        
+        UnionMetas = unionMetasList.ToArray();
     }
 
     public bool IsPartial()

--- a/VYaml.SourceGenerator/VYamlIncrementalSourceGenerator.cs
+++ b/VYaml.SourceGenerator/VYamlIncrementalSourceGenerator.cs
@@ -11,7 +11,7 @@ public class VYamlIncrementalSourceGenerator : IIncrementalGenerator
 {
     public void Initialize(IncrementalGeneratorInitializationContext context)
     {
-        var provider = context.SyntaxProvider
+        var yamlObjectProvider = context.SyntaxProvider
             .ForAttributeWithMetadataName(
                 context,
                 "VYaml.Annotations.YamlObjectAttribute",
@@ -26,27 +26,61 @@ public class VYamlIncrementalSourceGenerator : IIncrementalGenerator
             .Combine(context.CompilationProvider)
             .WithComparer(Comparer.Instance);
 
+        var yamlUnionMemberProvider = context.SyntaxProvider
+            .ForAttributeWithMetadataName(
+                context,
+                "VYaml.Annotations.YamlUnionMemberAttribute",
+                static (node, cancellation) =>
+                {
+                    return node is ClassDeclarationSyntax
+                        or StructDeclarationSyntax
+                        or RecordDeclarationSyntax;
+                },
+                static (context, cancellation) => context)
+            .Combine(context.CompilationProvider)
+            .WithComparer(Comparer.Instance);
+
         // Generate the source code.
         context.RegisterSourceOutput(
-            context.CompilationProvider.Combine(provider.Collect()),
+            context.CompilationProvider.Combine(yamlObjectProvider.Collect()).Combine(yamlUnionMemberProvider.Collect()),
             (sourceProductionContext, t) =>
             {
-                var (compilation, list) = t;
+                var ((compilation, yamlObjectList), yamlUnionMemberList) = t;
                 var references = ReferenceSymbols.Create(compilation);
                 if (references is null)
                 {
                     return;
                 }
 
+                // Collect union member information
+                var unionMembersByType = new Dictionary<INamedTypeSymbol, List<(string Tag, INamedTypeSymbol SubType)>>(SymbolEqualityComparer.Default);
+                foreach (var (x, _) in yamlUnionMemberList)
+                {
+                    var attr = x.Attributes.First();
+                    if (attr.ConstructorArguments.Length == 2)
+                    {
+                        var tag = (string)attr.ConstructorArguments[0].Value!;
+                        var unionType = (INamedTypeSymbol)attr.ConstructorArguments[1].Value!;
+                        
+                        if (!unionMembersByType.TryGetValue(unionType, out var list))
+                        {
+                            list = new List<(string, INamedTypeSymbol)>();
+                            unionMembersByType[unionType] = list;
+                        }
+                        list.Add((tag, (INamedTypeSymbol)x.TargetSymbol));
+                    }
+                }
+
                 var codeWriter = new CodeWriter();
 
-                foreach (var (x, _) in list)
+                foreach (var (x, _) in yamlObjectList)
                 {
                     var typeMeta = new TypeMeta(
                         (TypeDeclarationSyntax)x.TargetNode,
                         (INamedTypeSymbol)x.TargetSymbol,
                         x.Attributes.First(),
-                        references);
+                        references,
+                        unionMembersByType);
 
                     if (Emitter.TryEmit(typeMeta, codeWriter, references, sourceProductionContext))
                     {

--- a/VYaml.Tests/Serialization/UnionMemberAttributeTest.cs
+++ b/VYaml.Tests/Serialization/UnionMemberAttributeTest.cs
@@ -1,0 +1,149 @@
+using System;
+using NUnit.Framework;
+using VYaml.Internal;
+using VYaml.Serialization;
+using VYaml.Tests.TypeDeclarations;
+
+namespace VYaml.Tests.Serialization
+{
+    [TestFixture]
+    public class UnionMemberAttributeTest
+    {
+        [Test]
+        public void SerializeDeserialize_InterfaceWithUnionMemberAttribute()
+        {
+            var container = new ContainerWithUnionMemberAttribute
+            {
+                Name = "Test Container",
+                Item = new UnionMember1 { Value = 42, Name = "First" }
+            };
+
+            var utf8Yaml = YamlSerializer.SerializeToString(container);
+
+            Assert.That(utf8Yaml, Does.Contain("name: Test Container"));
+            Assert.That(utf8Yaml, Does.Contain("!member1"));
+            Assert.That(utf8Yaml, Does.Contain("value: 42"));
+            Assert.That(utf8Yaml, Does.Contain("name: First"));
+
+            var deserialized =
+                YamlSerializer.Deserialize<ContainerWithUnionMemberAttribute>(StringEncoding.Utf8.GetBytes(utf8Yaml));
+
+            Assert.That(deserialized, Is.Not.Null);
+            Assert.That(deserialized.Name, Is.EqualTo("Test Container"));
+            Assert.That(deserialized.Item, Is.TypeOf<UnionMember1>());
+            var item1 = (UnionMember1)deserialized.Item;
+            Assert.That(item1.Value, Is.EqualTo(42));
+            Assert.That(item1.Name, Is.EqualTo("First"));
+        }
+
+        [Test]
+        public void SerializeDeserialize_AbstractClassWithUnionMemberAttribute()
+        {
+            var container = new ContainerWithAbstractUnionMemberAttribute
+            {
+                Code = 100,
+                Data = new ConcreteUnionMember2 { IsActive = true }
+            };
+
+            var utf8Yaml = YamlSerializer.SerializeToString(container);
+
+            Assert.That(utf8Yaml, Does.Contain("code: 100"));
+            Assert.That(utf8Yaml, Does.Contain("!concrete2"));
+            Assert.That(utf8Yaml, Does.Contain("isActive: true"));
+
+            var deserialized =
+                YamlSerializer.Deserialize<ContainerWithAbstractUnionMemberAttribute>(
+                    StringEncoding.Utf8.GetBytes(utf8Yaml));
+
+            Assert.That(deserialized, Is.Not.Null);
+            Assert.That(deserialized.Code, Is.EqualTo(100));
+            Assert.That(deserialized.Data, Is.TypeOf<ConcreteUnionMember2>());
+            var data2 = (ConcreteUnionMember2)deserialized.Data;
+            Assert.That(data2.IsActive, Is.True);
+            Assert.That(data2.Type, Is.EqualTo("Type2"));
+        }
+
+        [Test]
+        public void SerializeDeserialize_MixedUnionAttributes()
+        {
+            // Test with traditional YamlObjectUnion member
+            var container1 = new ContainerWithMixedUnion
+            {
+                Title = "Mixed Test 1",
+                Content = new MixedUnionMember1 { Id = "id-001", Version = 5 }
+            };
+
+            var yaml1 = YamlSerializer.SerializeToString(container1);
+            Assert.That(yaml1, Does.Contain("!mixed1"));
+
+            var deserialized1 =
+                YamlSerializer.Deserialize<ContainerWithMixedUnion>(StringEncoding.Utf8.GetBytes(yaml1));
+            Assert.That(deserialized1.Content, Is.TypeOf<MixedUnionMember1>());
+            Assert.That(((MixedUnionMember1)deserialized1.Content).Version, Is.EqualTo(5));
+
+            // Test with YamlUnionMember attribute
+            var container2 = new ContainerWithMixedUnion
+            {
+                Title = "Mixed Test 2",
+                Content = new MixedUnionMember2 { Id = "id-002", Timestamp = new DateTime(2024, 1, 1) }
+            };
+
+            var yaml2 = YamlSerializer.SerializeToString(container2);
+            Assert.That(yaml2, Does.Contain("!mixed2"));
+
+            var deserialized2 =
+                YamlSerializer.Deserialize<ContainerWithMixedUnion>(StringEncoding.Utf8.GetBytes(yaml2));
+            Assert.That(deserialized2.Content, Is.TypeOf<MixedUnionMember2>());
+            Assert.That(((MixedUnionMember2)deserialized2.Content).Timestamp, Is.EqualTo(new DateTime(2024, 1, 1)));
+        }
+
+        [Test]
+        public void SerializeDeserialize_MultipleUnionMembers()
+        {
+            // Test switching between different union members
+            var yaml1 = @"name: Container 1
+item: !member1
+  value: 10
+  name: Item One";
+
+            var container1 =
+                YamlSerializer.Deserialize<ContainerWithUnionMemberAttribute>(StringEncoding.Utf8.GetBytes(yaml1));
+            Assert.That(container1.Item, Is.TypeOf<UnionMember1>());
+            Assert.That(((UnionMember1)container1.Item).Name, Is.EqualTo("Item One"));
+
+            var yaml2 = @"name: Container 2
+item: !member2
+  value: 20
+  price: 99.99";
+
+            var container2 =
+                YamlSerializer.Deserialize<ContainerWithUnionMemberAttribute>(StringEncoding.Utf8.GetBytes(yaml2));
+            Assert.That(container2.Item, Is.TypeOf<UnionMember2>());
+            Assert.That(((UnionMember2)container2.Item).Price, Is.EqualTo(99.99m));
+        }
+
+        [Test]
+        public void SerializeDeserialize_AbstractUnionRoundTrip()
+        {
+            var original1 = new ConcreteUnionMember1 { Count = 123 };
+            var yaml1 = YamlSerializer.SerializeToString(original1);
+            Assert.That(yaml1, Does.Contain("!concrete1"));
+
+            var restored1 =
+                YamlSerializer.Deserialize<AbstractUnionWithMemberAttribute>(StringEncoding.Utf8.GetBytes(yaml1));
+            Assert.That(restored1, Is.TypeOf<ConcreteUnionMember1>());
+            Assert.That(((ConcreteUnionMember1)restored1).Count, Is.EqualTo(123));
+            Assert.That(restored1.Type, Is.EqualTo("Type1"));
+
+            var original2 = new ConcreteUnionMember2 { IsActive = false };
+            var yaml2 = YamlSerializer.SerializeToString(original2);
+            Assert.That(yaml2, Does.Contain("!concrete2"));
+
+            var restored2 =
+                YamlSerializer.Deserialize<AbstractUnionWithMemberAttribute>(StringEncoding.Utf8.GetBytes(yaml2));
+            Assert.That(restored2, Is.TypeOf<ConcreteUnionMember2>());
+            Assert.That(((ConcreteUnionMember2)restored2).IsActive, Is.False);
+            Assert.That(restored2.Type, Is.EqualTo("Type2"));
+        }
+    }
+}

--- a/VYaml.Tests/Serialization/UnionMemberAttributeTest.cs
+++ b/VYaml.Tests/Serialization/UnionMemberAttributeTest.cs
@@ -10,7 +10,7 @@ namespace VYaml.Tests.Serialization
     public class UnionMemberAttributeTest
     {
         [Test]
-        public void SerializeDeserialize_InterfaceWithUnionMemberAttribute()
+        public void Serialize_InterfaceWithUnionMemberAttribute()
         {
             var container = new ContainerWithUnionMemberAttribute
             {
@@ -20,24 +20,39 @@ namespace VYaml.Tests.Serialization
 
             var utf8Yaml = YamlSerializer.SerializeToString(container);
 
-            Assert.That(utf8Yaml, Does.Contain("name: Test Container"));
-            Assert.That(utf8Yaml, Does.Contain("!member1"));
-            Assert.That(utf8Yaml, Does.Contain("value: 42"));
-            Assert.That(utf8Yaml, Does.Contain("name: First"));
-
-            var deserialized =
-                YamlSerializer.Deserialize<ContainerWithUnionMemberAttribute>(StringEncoding.Utf8.GetBytes(utf8Yaml));
-
-            Assert.That(deserialized, Is.Not.Null);
-            Assert.That(deserialized.Name, Is.EqualTo("Test Container"));
-            Assert.That(deserialized.Item, Is.TypeOf<UnionMember1>());
-            var item1 = (UnionMember1)deserialized.Item;
-            Assert.That(item1.Value, Is.EqualTo(42));
-            Assert.That(item1.Name, Is.EqualTo("First"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(utf8Yaml, Does.Contain("name: Test Container"));
+                Assert.That(utf8Yaml, Does.Contain("!member1"));
+                Assert.That(utf8Yaml, Does.Contain("value: 42"));
+                Assert.That(utf8Yaml, Does.Contain("name: First"));
+            });
         }
 
         [Test]
-        public void SerializeDeserialize_AbstractClassWithUnionMemberAttribute()
+        public void Deserialize_InterfaceWithUnionMemberAttribute()
+        {
+            var yaml = @"name: Test Container
+item: !member1
+  value: 42
+  name: First";
+
+            var deserialized =
+                YamlSerializer.Deserialize<ContainerWithUnionMemberAttribute>(StringEncoding.Utf8.GetBytes(yaml));
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(deserialized, Is.Not.Null);
+                Assert.That(deserialized.Name, Is.EqualTo("Test Container"));
+                Assert.That(deserialized.Item, Is.TypeOf<UnionMember1>());
+                var item1 = (UnionMember1)deserialized.Item;
+                Assert.That(item1.Value, Is.EqualTo(42));
+                Assert.That(item1.Name, Is.EqualTo("First"));
+            });
+        }
+
+        [Test]
+        public void Serialize_AbstractClassWithUnionMemberAttribute()
         {
             var container = new ContainerWithAbstractUnionMemberAttribute
             {
@@ -47,26 +62,39 @@ namespace VYaml.Tests.Serialization
 
             var utf8Yaml = YamlSerializer.SerializeToString(container);
 
-            Assert.That(utf8Yaml, Does.Contain("code: 100"));
-            Assert.That(utf8Yaml, Does.Contain("!concrete2"));
-            Assert.That(utf8Yaml, Does.Contain("isActive: true"));
-
-            var deserialized =
-                YamlSerializer.Deserialize<ContainerWithAbstractUnionMemberAttribute>(
-                    StringEncoding.Utf8.GetBytes(utf8Yaml));
-
-            Assert.That(deserialized, Is.Not.Null);
-            Assert.That(deserialized.Code, Is.EqualTo(100));
-            Assert.That(deserialized.Data, Is.TypeOf<ConcreteUnionMember2>());
-            var data2 = (ConcreteUnionMember2)deserialized.Data;
-            Assert.That(data2.IsActive, Is.True);
-            Assert.That(data2.Type, Is.EqualTo("Type2"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(utf8Yaml, Does.Contain("code: 100"));
+                Assert.That(utf8Yaml, Does.Contain("!concrete2"));
+                Assert.That(utf8Yaml, Does.Contain("isActive: true"));
+            });
         }
 
         [Test]
-        public void SerializeDeserialize_MixedUnionAttributes()
+        public void Deserialize_AbstractClassWithUnionMemberAttribute()
         {
-            // Test with traditional YamlObjectUnion member
+            var yaml = @"code: 100
+data: !concrete2
+  isActive: true";
+
+            var deserialized =
+                YamlSerializer.Deserialize<ContainerWithAbstractUnionMemberAttribute>(
+                    StringEncoding.Utf8.GetBytes(yaml));
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(deserialized, Is.Not.Null);
+                Assert.That(deserialized.Code, Is.EqualTo(100));
+                Assert.That(deserialized.Data, Is.TypeOf<ConcreteUnionMember2>());
+                var data2 = (ConcreteUnionMember2)deserialized.Data;
+                Assert.That(data2.IsActive, Is.True);
+                Assert.That(data2.Type, Is.Null); // Type is not set in yaml
+            });
+        }
+
+        [Test]
+        public void Serialize_Mixed_YamlObjectUnionAttribute()
+        {
             var container1 = new ContainerWithMixedUnion
             {
                 Title = "Mixed Test 1",
@@ -74,14 +102,13 @@ namespace VYaml.Tests.Serialization
             };
 
             var yaml1 = YamlSerializer.SerializeToString(container1);
+
             Assert.That(yaml1, Does.Contain("!mixed1"));
+        }
 
-            var deserialized1 =
-                YamlSerializer.Deserialize<ContainerWithMixedUnion>(StringEncoding.Utf8.GetBytes(yaml1));
-            Assert.That(deserialized1.Content, Is.TypeOf<MixedUnionMember1>());
-            Assert.That(((MixedUnionMember1)deserialized1.Content).Version, Is.EqualTo(5));
-
-            // Test with YamlUnionMember attribute
+        [Test]
+        public void Serialize_Mixed_YamlUnionMemberAttribute()
+        {
             var container2 = new ContainerWithMixedUnion
             {
                 Title = "Mixed Test 2",
@@ -89,18 +116,89 @@ namespace VYaml.Tests.Serialization
             };
 
             var yaml2 = YamlSerializer.SerializeToString(container2);
-            Assert.That(yaml2, Does.Contain("!mixed2"));
 
-            var deserialized2 =
-                YamlSerializer.Deserialize<ContainerWithMixedUnion>(StringEncoding.Utf8.GetBytes(yaml2));
-            Assert.That(deserialized2.Content, Is.TypeOf<MixedUnionMember2>());
-            Assert.That(((MixedUnionMember2)deserialized2.Content).Timestamp, Is.EqualTo(new DateTime(2024, 1, 1)));
+            Assert.That(yaml2, Does.Contain("!mixed2"));
         }
 
         [Test]
-        public void SerializeDeserialize_MultipleUnionMembers()
+        public void Deserialize_Mixed_YamlObjectUnionAttribute()
         {
-            // Test switching between different union members
+            var yaml1 = @"title: Mixed Test 1
+content: !mixed1
+  id: id-001
+  version: 5";
+
+            var deserialized1 =
+                YamlSerializer.Deserialize<ContainerWithMixedUnion>(StringEncoding.Utf8.GetBytes(yaml1));
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(deserialized1.Content, Is.TypeOf<MixedUnionMember1>());
+                Assert.That(((MixedUnionMember1)deserialized1.Content).Version, Is.EqualTo(5));
+            });
+        }
+
+        [Test]
+        public void Deserialize_Mixed_YamlUnionMemberAttribute()
+        {
+            var yaml2 = @"title: Mixed Test 2
+content: !mixed2
+  id: id-002
+  timestamp: 2024-01-01T00:00:00";
+
+            var deserialized2 =
+                YamlSerializer.Deserialize<ContainerWithMixedUnion>(StringEncoding.Utf8.GetBytes(yaml2));
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(deserialized2.Content, Is.TypeOf<MixedUnionMember2>());
+                Assert.That(((MixedUnionMember2)deserialized2.Content).Timestamp, Is.EqualTo(new DateTime(2024, 1, 1)));
+            });
+        }
+
+        [Test]
+        public void Serialize_MultipleUnionMembers_YamlObjectUnionAttribute()
+        {
+            var container1 = new ContainerWithUnionMemberAttribute
+            {
+                Name = "Container 1",
+                Item = new UnionMember1 { Value = 10, Name = "Item One" }
+            };
+
+            var yaml1 = YamlSerializer.SerializeToString(container1);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(yaml1, Does.Contain("name: Container 1"));
+                Assert.That(yaml1, Does.Contain("!member1"));
+                Assert.That(yaml1, Does.Contain("value: 10"));
+                Assert.That(yaml1, Does.Contain("name: Item One"));
+            });
+        }
+
+        [Test]
+        public void Serialize_MultipleUnionMembers_YamlUnionMemberAttribute()
+        {
+            var container2 = new ContainerWithUnionMemberAttribute
+            {
+                Name = "Container 2",
+                Item = new UnionMember2 { Value = 20, Price = 99.99m }
+            };
+
+            var yaml2 = YamlSerializer.SerializeToString(container2);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(yaml2, Does.Contain("name: Container 2"));
+                Assert.That(yaml2, Does.Contain("!member2"));
+                Assert.That(yaml2, Does.Contain("value: 20"));
+                Assert.That(yaml2, Does.Contain("price: 99.99"));
+            });
+        }
+
+        [Test]
+        public void Deserialize_MultipleUnionMembers_YamlObjectUnionAttribute()
+        {
             var yaml1 = @"name: Container 1
 item: !member1
   value: 10
@@ -108,9 +206,17 @@ item: !member1
 
             var container1 =
                 YamlSerializer.Deserialize<ContainerWithUnionMemberAttribute>(StringEncoding.Utf8.GetBytes(yaml1));
-            Assert.That(container1.Item, Is.TypeOf<UnionMember1>());
-            Assert.That(((UnionMember1)container1.Item).Name, Is.EqualTo("Item One"));
 
+            Assert.Multiple(() =>
+            {
+                Assert.That(container1.Item, Is.TypeOf<UnionMember1>());
+                Assert.That(((UnionMember1)container1.Item).Name, Is.EqualTo("Item One"));
+            });
+        }
+
+        [Test]
+        public void Deserialize_MultipleUnionMembers_YamlUnionMemberAttribute()
+        {
             var yaml2 = @"name: Container 2
 item: !member2
   value: 20
@@ -118,32 +224,12 @@ item: !member2
 
             var container2 =
                 YamlSerializer.Deserialize<ContainerWithUnionMemberAttribute>(StringEncoding.Utf8.GetBytes(yaml2));
-            Assert.That(container2.Item, Is.TypeOf<UnionMember2>());
-            Assert.That(((UnionMember2)container2.Item).Price, Is.EqualTo(99.99m));
-        }
 
-        [Test]
-        public void SerializeDeserialize_AbstractUnionRoundTrip()
-        {
-            var original1 = new ConcreteUnionMember1 { Count = 123 };
-            var yaml1 = YamlSerializer.SerializeToString(original1);
-            Assert.That(yaml1, Does.Contain("!concrete1"));
-
-            var restored1 =
-                YamlSerializer.Deserialize<AbstractUnionWithMemberAttribute>(StringEncoding.Utf8.GetBytes(yaml1));
-            Assert.That(restored1, Is.TypeOf<ConcreteUnionMember1>());
-            Assert.That(((ConcreteUnionMember1)restored1).Count, Is.EqualTo(123));
-            Assert.That(restored1.Type, Is.EqualTo("Type1"));
-
-            var original2 = new ConcreteUnionMember2 { IsActive = false };
-            var yaml2 = YamlSerializer.SerializeToString(original2);
-            Assert.That(yaml2, Does.Contain("!concrete2"));
-
-            var restored2 =
-                YamlSerializer.Deserialize<AbstractUnionWithMemberAttribute>(StringEncoding.Utf8.GetBytes(yaml2));
-            Assert.That(restored2, Is.TypeOf<ConcreteUnionMember2>());
-            Assert.That(((ConcreteUnionMember2)restored2).IsActive, Is.False);
-            Assert.That(restored2.Type, Is.EqualTo("Type2"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(container2.Item, Is.TypeOf<UnionMember2>());
+                Assert.That(((UnionMember2)container2.Item).Price, Is.EqualTo(99.99m));
+            });
         }
     }
 }

--- a/VYaml.Tests/TypeDeclarations/UnionMember.cs
+++ b/VYaml.Tests/TypeDeclarations/UnionMember.cs
@@ -1,0 +1,96 @@
+using System;
+using VYaml.Annotations;
+
+namespace VYaml.Tests.TypeDeclarations
+{
+    // Test for YamlUnionMemberAttribute - interface approach
+    [YamlObject]
+    public partial interface IUnionWithMemberAttribute
+    {
+        public int Value { get; }
+    }
+
+    [YamlObject]
+    [YamlUnionMember("!member1", typeof(IUnionWithMemberAttribute))]
+    public partial class UnionMember1 : IUnionWithMemberAttribute
+    {
+        public int Value { get; set; }
+        public string Name { get; set; } = default!;
+    }
+
+    [YamlObject]
+    [YamlUnionMember("!member2", typeof(IUnionWithMemberAttribute))]
+    public partial class UnionMember2 : IUnionWithMemberAttribute
+    {
+        public int Value { get; set; }
+        public decimal Price { get; set; }
+    }
+
+    // Test for YamlUnionMemberAttribute - abstract class approach
+    [YamlObject]
+    public abstract partial class AbstractUnionWithMemberAttribute
+    {
+        public abstract string Type { get; set; }
+    }
+
+    [YamlObject]
+    [YamlUnionMember("!concrete1", typeof(AbstractUnionWithMemberAttribute))]
+    public partial class ConcreteUnionMember1 : AbstractUnionWithMemberAttribute
+    {
+        public override string Type { get; set; } = "Type1";
+        public int Count { get; set; }
+    }
+
+    [YamlObject]
+    [YamlUnionMember("!concrete2", typeof(AbstractUnionWithMemberAttribute))]
+    public partial class ConcreteUnionMember2 : AbstractUnionWithMemberAttribute
+    {
+        public override string Type { get; set; } = "Type2";
+        public bool IsActive { get; set; }
+    }
+
+    // Test for mixed approach - both attributes
+    [YamlObject]
+    [YamlObjectUnion("!mixed1", typeof(MixedUnionMember1))]
+    public partial interface IMixedUnion
+    {
+        public string Id { get; }
+    }
+
+    [YamlObject]
+    public partial class MixedUnionMember1 : IMixedUnion
+    {
+        public string Id { get; set; } = default!;
+        public int Version { get; set; }
+    }
+
+    [YamlObject]
+    [YamlUnionMember("!mixed2", typeof(IMixedUnion))]
+    public partial class MixedUnionMember2 : IMixedUnion
+    {
+        public string Id { get; set; } = default!;
+        public DateTime Timestamp { get; set; }
+    }
+
+    // Test container classes
+    [YamlObject]
+    public partial class ContainerWithUnionMemberAttribute
+    {
+        public string Name { get; set; } = default!;
+        public IUnionWithMemberAttribute Item { get; set; } = default!;
+    }
+
+    [YamlObject]
+    public partial class ContainerWithAbstractUnionMemberAttribute
+    {
+        public int Code { get; set; }
+        public AbstractUnionWithMemberAttribute Data { get; set; } = default!;
+    }
+
+    [YamlObject]
+    public partial class ContainerWithMixedUnion
+    {
+        public string Title { get; set; } = default!;
+        public IMixedUnion Content { get; set; } = default!;
+    }
+}


### PR DESCRIPTION
## Motivation

`[YamlObjectUnion]` attribute needs to be attached to an interface or abstract class.
So, in libraries (NuGet or UPM packages) that use VYaml, it cannot be extended by the project.


## New Features

#### Polymorphism (Union from derived or implementation class)

You can also define union relationships from the derived or implementation class side using `[YamlUnionMember]`.
This approach is practical when you want to add new implementations without modifying the base type.

``` csharp
[YamlObject]
public partial interface IUnionSample2
{
}

[YamlObject]
[YamlUnionMember("!baz", typeof(IUnionSample2))]
public partial class BazClass : IUnionSample2
{
    public int A { get; set; }
}
```

This works the same as `YamlObjectUnion` attribute:

``` csharp
// We can deserialize as interface type.
var obj = YamlSerializer.Deserialize<IUnionSample2>(UTF8.GetBytes("!baz { a: 100 }"));

Assert.That(obj, Is.TypeOf<BazClass>());
```

You can also serialize:

``` csharp
YamlSerializer.Serialize<IUnionSample2>(new Baz { A = 100 });
```

Result:
``` yaml
!baz
a: 100
```

Both approaches can be mixed within the same union type:

``` csharp
[YamlObject]
[YamlObjectUnion("!qux", typeof(QuxClass))]
public partial interface IMixedUnion
{
}

[YamlObject]
public partial class QuxClass : IMixedUnion { }

[YamlObject]
[YamlUnionMember("!quux", typeof(IMixedUnion))]
public partial class QuuxClass : IMixedUnion { }
```


## Discussions

The attribute names were suggested by Claude Code. You can change them if you prefer.