### PR TITLE
Improve generic type support

### DIFF
--- a/VYaml.SourceGenerator.Roslyn3/VYamlSourceGenerator.cs
+++ b/VYaml.SourceGenerator.Roslyn3/VYamlSourceGenerator.cs
@@ -35,7 +35,9 @@ public class VYamlSourceGenerator : ISourceGenerator
                     var fullType = typeMeta.FullTypeName
                         .Replace("global::", "")
                         .Replace("<", "_")
-                        .Replace(">", "_");
+                        .Replace(">", "_")
+                        .Replace(",", "_")
+                        .Replace(" ", "");
 
                     context.AddSource($"{fullType}.YamlFormatter.g.cs", codeWriter.ToString());
                 }
@@ -253,7 +255,9 @@ public class VYamlSourceGenerator : ISourceGenerator
     {
         codeWriter.AppendLine("[VYaml.Annotations.Preserve]");
         using var _ = codeWriter.BeginBlockScope("public static void __RegisterVYamlFormatter()");
-        codeWriter.AppendLine($"global::VYaml.Serialization.GeneratedResolver.Register(new {typeMeta.TypeName}GeneratedFormatter());");
+
+        var typeName = typeMeta.TypeName.Replace("<", "_").Replace(">", "_").Replace(",", "_").Replace(" ", "");
+        codeWriter.AppendLine($"global::VYaml.Serialization.GeneratedResolver.Register(new {typeName}GeneratedFormatter());");
         return true;
     }
 
@@ -268,7 +272,9 @@ public class VYamlSourceGenerator : ISourceGenerator
             : $"{typeMeta.FullTypeName}?";
 
         codeWriter.AppendLine("[VYaml.Annotations.Preserve]");
-        using var _ = codeWriter.BeginBlockScope($"public class {typeMeta.TypeName}GeneratedFormatter : IYamlFormatter<{returnType}>");
+
+        var typeName = typeMeta.TypeName.Replace("<", "_").Replace(">", "_").Replace(",", "_").Replace(" ", "");
+        using var _ = codeWriter.BeginBlockScope($"public class {typeName}GeneratedFormatter : IYamlFormatter<{returnType}>");
 
         // Union
         if (typeMeta.IsUnion)

--- a/VYaml.SourceGenerator/Emitter.cs
+++ b/VYaml.SourceGenerator/Emitter.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.CodeAnalysis;
@@ -216,7 +216,9 @@ static class Emitter
     {
         codeWriter.AppendLine("[VYaml.Annotations.Preserve]");
         using var _ = codeWriter.BeginBlockScope("public static void __RegisterVYamlFormatter()");
-        codeWriter.AppendLine($"global::VYaml.Serialization.GeneratedResolver.Register(new {typeMeta.TypeName}GeneratedFormatter());");
+
+        var typeName = typeMeta.TypeName.Replace("<", "_").Replace(">", "_").Replace(",", "_").Replace(" ", "");
+        codeWriter.AppendLine($"global::VYaml.Serialization.GeneratedResolver.Register(new {typeName}GeneratedFormatter());");
         return true;
     }
 
@@ -231,7 +233,9 @@ static class Emitter
             : $"{typeMeta.FullTypeName}?";
 
         codeWriter.AppendLine("[VYaml.Annotations.Preserve]");
-        using var _ = codeWriter.BeginBlockScope($"public class {typeMeta.TypeName}GeneratedFormatter : IYamlFormatter<{returnType}>");
+
+        var typeName = typeMeta.TypeName.Replace("<", "_").Replace(">", "_").Replace(",", "_").Replace(" ", "");
+        using var _ = codeWriter.BeginBlockScope($"public class {typeName}GeneratedFormatter : IYamlFormatter<{returnType}>");
 
         // Union
         if (typeMeta.IsUnion)

--- a/VYaml.SourceGenerator/VYamlIncrementalSourceGenerator.cs
+++ b/VYaml.SourceGenerator/VYamlIncrementalSourceGenerator.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -53,7 +53,9 @@ public class VYamlIncrementalSourceGenerator : IIncrementalGenerator
                         var fullType = typeMeta.FullTypeName
                             .Replace("global::", "")
                             .Replace("<", "_")
-                            .Replace(">", "_");
+                            .Replace(">", "_")
+                            .Replace(",", "_")
+                            .Replace(" ", "");
 
                         sourceProductionContext.AddSource($"{fullType}.YamlFormatter.g.cs", codeWriter.ToString());
                     }

--- a/VYaml.Tests/Serialization/GeneratedFormatterTest.cs
+++ b/VYaml.Tests/Serialization/GeneratedFormatterTest.cs
@@ -1,8 +1,9 @@
+﻿using NUnit.Framework;
 using System;
-using NUnit.Framework;
 using VYaml.Annotations;
 using VYaml.Serialization;
 using VYaml.Tests.TypeDeclarations;
+
 
 namespace VYaml.Tests.Serialization
 {
@@ -237,6 +238,21 @@ namespace VYaml.Tests.Serialization
 
         }
 
+        public void Seralize_GenericType()
+        {
+            var result = Serialize(new GenericType<int>
+            {
+                Value = 100
+            });
+            Assert.That(result, Is.EqualTo("one: 100\n"));
+            var result2 = Serialize(new GenericType<int, string>
+            {
+                Foo = 111,
+                Bar = "aaa"
+            });
+            Assert.That(result2, Is.EqualTo("foo: 111\nbar: aaa\n"));
+        }
+
         [Test]
         public void Deserialize_NoMember()
         {
@@ -458,5 +474,16 @@ namespace VYaml.Tests.Serialization
                 new YamlSerializerOptions { NamingConvention = NamingConvention.UpperCamelCase });
             Assert.That(result2.B, Is.EqualTo(123));
         }
+
+        public void Deserialize_GenericType()
+        {
+            var result = Deserialize<GenericType<int>>("{ one: 100 }");
+            Assert.That(result.Value, Is.EqualTo(100));
+
+            var result2 = Deserialize<GenericType<int, string>>("{ foo: 111, bar: aaa }");
+            Assert.That(result2.Foo, Is.EqualTo(111));
+            Assert.That(result2.Bar, Is.EqualTo("aaa"));
+        }
+
     }
 }

--- a/VYaml.Tests/TypeDeclarations/Simple.cs
+++ b/VYaml.Tests/TypeDeclarations/Simple.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Runtime.Serialization;
 using VYaml.Annotations;
 
@@ -298,6 +298,20 @@ namespace VYaml.Tests.TypeDeclarations
             UshortValue = ushortValue;
             ByteValue = byteValue;
         }
+    }
+
+    [YamlObject]
+    public partial class GenericType<T>
+    {
+        public T? Value { get; set; }
+    }
+
+    [YamlObject]
+    public partial class GenericType<T, T2>
+    {
+        public T? Foo { get; set; }
+
+        public T2? Bar { get; set; }
     }
 }
 


### PR DESCRIPTION
This PR improves serialization support for generic types.
When using `YamlObjectAttribute` with generic types like `GenericType<int, string>`, source generator was creating invalid identifiers containing commas and angle brackets, which resulted in compilation failures. Therefore, I fixed the issue by replacing these invalid characters with underscores to ensure valid identifiers are generated.