### PR TITLE
Fix buffer overflow when serializing strings longer than 2048 chars

### DIFF
--- a/VYaml.Tests/Serialization/SerializerTest.cs
+++ b/VYaml.Tests/Serialization/SerializerTest.cs
@@ -173,6 +173,14 @@ namespace VYaml.Tests.Serialization
         }
 
         [Test]
+        public void Serialize_LongString()
+        {
+            var longString = new string('a', 3000);
+            var result = YamlSerializer.SerializeToString(longString);
+            Assert.That(result, Does.Contain(longString));
+        }
+
+        [Test]
         public void Deserialize_Empty()
         {
             var empty = new ReadOnlyMemory<byte>(Array.Empty<byte>());

--- a/VYaml/Internal/ExpandBuffer.cs
+++ b/VYaml/Internal/ExpandBuffer.cs
@@ -31,7 +31,7 @@ namespace VYaml.Internal
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public Span<T> AsSpan(int length)
         {
-            if (length > buffer.Length)
+            while (length > buffer.Length)
             {
                 SetCapacity(buffer.Length * 2);
             }


### PR DESCRIPTION
## Summary
- Fix `ExpandBuffer<T>.AsSpan(int length)` to use `while` instead of `if` when growing the buffer
- The buffer only doubled once (1024→2048), so strings exceeding 2048 chars caused `ArgumentOutOfRangeException`

Closes #168

## Test plan
- [x] Added `Serialize_LongString` test with a 3000-char string
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)