### PR TITLE
Fix compiler warnings CS0108 and CS8604

### DIFF
--- a/VYaml.SourceGenerator/Emitter.cs
+++ b/VYaml.SourceGenerator/Emitter.cs
@@ -215,7 +215,13 @@ static class Emitter
     static bool TryEmitRegisterMethod(TypeMeta typeMeta, CodeWriter codeWriter, in SourceProductionContext context)
     {
         codeWriter.AppendLine("[VYaml.Annotations.Preserve]");
-        using var _ = codeWriter.BeginBlockScope("public static void __RegisterVYamlFormatter()");
+        // Use 'new' modifier when base type also has [YamlObject] to avoid CS0108
+        var hasBaseYamlObject = typeMeta.Symbol.BaseType != null &&
+                                typeMeta.Symbol.BaseType.GetAttributes().Any(a =>
+                                    a.AttributeClass != null &&
+                                    a.AttributeClass.ToDisplayString() == "VYaml.Annotations.YamlObjectAttribute");
+        var modifier = hasBaseYamlObject ? "public static new" : "public static";
+        using var _ = codeWriter.BeginBlockScope($"{modifier} void __RegisterVYamlFormatter()");
 
         var typeName = typeMeta.TypeName.Replace("<", "_").Replace(">", "_").Replace(",", "_").Replace(" ", "");
         codeWriter.AppendLine($"global::VYaml.Serialization.GeneratedResolver.Register(new {typeName}GeneratedFormatter());");

--- a/VYaml.SourceGenerator/Shims/CSharpSyntaxHelper.cs
+++ b/VYaml.SourceGenerator/Shims/CSharpSyntaxHelper.cs
@@ -56,7 +56,7 @@ namespace Microsoft.CodeAnalysis.DotnetRuntime.Extensions
             }
             else
             {
-                targets.Append(container);
+                targets.Append(container!);
             }
         }
 

--- a/VYaml/Serialization/Formatters/ByteArrayFormatter.cs
+++ b/VYaml/Serialization/Formatters/ByteArrayFormatter.cs
@@ -126,7 +126,7 @@ namespace VYaml.Serialization
         public void Serialize(ref Utf8YamlEmitter emitter, ArraySegment<byte> value, YamlSerializationContext context)
         {
             emitter.WriteString(                
-                Convert.ToBase64String(value.Array, value.Offset, value.Count, Base64FormattingOptions.None),
+                Convert.ToBase64String(value.Array!, value.Offset, value.Count, Base64FormattingOptions.None),
                 ScalarStyle.Plain);
         }
 

--- a/VYaml/Serialization/Formatters/EnumAsStringFormatter.cs
+++ b/VYaml/Serialization/Formatters/EnumAsStringFormatter.cs
@@ -13,7 +13,7 @@ namespace VYaml.Serialization
     // TODO:
     static class EnumAsStringNonGenericHelper
     {
-        static readonly ConcurrentDictionary<object, string> AliasStringValues = new();
+        static readonly ConcurrentDictionary<object, string?> AliasStringValues = new();
         static readonly ConcurrentDictionary<Type, NamingConvention?> NamingConventionsByType = new();
 
         static readonly Func<object, Type, string?> AliasStringValueFactory = AnalyzeAliasStringValue;

--- a/VYaml/Serialization/Formatters/PrimitiveObjectFormatter.cs
+++ b/VYaml/Serialization/Formatters/PrimitiveObjectFormatter.cs
@@ -166,13 +166,13 @@ namespace VYaml.Serialization
                     break;
                 case ParseEventType.MappingStart:
                 {
-                    var dict = new Dictionary<object?, object?>();
+                    var dict = new Dictionary<object, object?>();
                     parser.Read();
                     while (!parser.End && parser.CurrentEventType != ParseEventType.MappingEnd)
                     {
                         var key = context.DeserializeWithAlias(this, ref parser);
                         var value = context.DeserializeWithAlias(this, ref parser);
-                        dict.Add(key, value);
+                        dict.Add(key!, value);
                     }
                     parser.ReadWithVerify(ParseEventType.MappingEnd);
                     result = dict;


### PR DESCRIPTION
## Summary
- Fix CS0108 warning: generated `__RegisterVYamlFormatter()` in derived types now uses `new` modifier when base type has `[YamlObject]`
- Fix CS8604 warning: add null-forgiving operator in `CSharpSyntaxHelper.cs` (copied from dotnet/runtime)

## Changes
- `VYaml.SourceGenerator/Emitter.cs` — Check if base type has `[YamlObject]` and emit `new` modifier accordingly
- `VYaml.SourceGenerator/Shims/CSharpSyntaxHelper.cs` — `container!` to suppress nullable warning

## Test plan
- [x] All tests pass
- [x] `dotnet build` produces zero CS warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)